### PR TITLE
Hbase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# puppet-cdh4
+# Description
 
 Puppet module to install and manage components of
 Cloudera's Distribution 4 (CDH4) for Apache Hadoop.
@@ -6,7 +6,6 @@ Cloudera's Distribution 4 (CDH4) for Apache Hadoop.
 NOTE: The main puppet-cdh4 repository is hosted in WMF Gerrit at
 [operations/puppet/cdh4](https://gerrit.wikimedia.org/r/#/admin/projects/operations/puppet/cdh4).
 
-# Description
 
 Installs HDFS, YARN or MR1, Hive, HBase, Pig, Sqoop, Zookeeper, Oozie and
 Hue.  Note that, in order for this module to work, you will have to ensure
@@ -16,14 +15,18 @@ that:
 - Your package manager is configured with a repository containing the
   Cloudera 4 packages.
 
-Notes:
+**Notes:**
 
+- In general, services managed by this module do not subscribe to their relevant
+config files.  This prevents accidental deployments of config changes.  If you
+make config changes in puppet, you must apply puppet and then manually restart
+the relevant services.
 - This module has only been tested using CDH 4.2.1 on Ubuntu Precise 12.04.2 LTS
 - Many of the above mentioned services are not yet implemented in v0.2.
   See the v0.1 branch if you'd like to use these now.
 
 
-# Installation:
+# Installation
 
 Clone (or copy) this repository into your puppet modules/cdh4 directory:
 ```bash
@@ -37,23 +40,33 @@ git commit -m 'Adding modules/cdh4 as a git submodule.'
 git submodule init && git submodule update
 ```
 
-# Usage
+# Hadoop
 
-## For all Hadoop nodes:
+## Hadoop Clients
+
+All Hadoop enabled nodes should include the ```cdh4::hadoop``` class.
 
 ```puppet
+class my::hadoop {
+    class { 'cdh4::hadoop':
+        # Must pass an array of hosts here, even if you are
+        # not using HA and only have a single NameNode.
+        namenode_hosts     => ['namenode1.domain.org'],
+        datanode_mounts    => [
+            '/var/lib/hadoop/data/a',
+            '/var/lib/hadoop/data/b',
+            '/var/lib/hadoop/data/c'
+        ],
+        # You can also provide an array of dfs_name_dirs.
+        dfs_name_dir       => '/var/lib/hadoop/name',
+    }
+}
 
-include cdh4
-class { "cdh4::hadoop":
-	namenode_hostname => "namenode.hostname.org",
-	datanode_mounts   => [
-	    "/var/lib/hadoop/data/a",
-	    "/var/lib/hadoop/data/b",
-	    "/var/lib/hadoop/data/c"
-	],
-	dfs_name_dir      => ["/var/lib/hadoop/name", "/mnt/hadoop_name"],
+node 'hadoop-client.domain.org' {
+    include my::hadoop
 }
 ```
+
 This will ensure that CDH4 client packages are installed, and that
 Hadoop related config files are in place with proper settings.
 
@@ -63,24 +76,193 @@ points provided.
 
 If you would like to use MRv1 instead of YARN, set ```use_yarn``` to false.
 
-## For your Hadoop master node:
+## Hadoop master
 
 ```puppet
-include cdh4::hadoop::master
+class my::hadoop::master inherits my::hadoop {
+    include cdh4::hadoop::master
+}
+
+node 'namenode1.domain.org' {
+    include my::hadoop::master
+}
 ```
+
 This installs and starts up the NameNode.  If using YARN this will install
 and set up ResourceManager and HistoryServer.  If using MRv1, this will install
 and set up the JobTracker.
 
-### For your Hadoop worker nodes:
+## Hadoop workers
 
 ```puppet
-include cdh4::hadoop::worker
+class my::hadoop::worker inherits my::hadoop {
+    include cdh4::hadoop::worker
+}
+
+node 'datanode[1234].domain.org' {
+    include my::hadoop::worker
+}
 ```
 
-This installs and starts up the DataNode.  If using YARN, this will install and set up the NodeManager.  If using MRv1, this will install and set up the TaskTracker.
+This installs and starts up the DataNode.  If using YARN, this will install
+and set up the NodeManager.  If using MRv1, this will install and set up the
+TaskTracker.
 
-## For all Hive enabled nodes:
+## High Availability NameNode
+
+For detailed documentation, see the
+[CDH4 High Availability Guide](http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.1/CDH4-High-Availability-Guide/CDH4-High-Availability-Guide.html).
+
+This puppet module only supports Quorum-based HA storage using JournalNodes.
+It does not support NFS based HA.
+
+Your JournalNodes will be automatically configured based on the value of
+```$cdh4::hadoop::journalnode_hosts```.  When ```cdh4::hadoop``` is included,
+if the current hostname or IP address matches a value in the $journalnode_hosts
+array, then ```cdh4::hadoop::journalnode``` will be included.
+
+Before applying ```cdh4::hadoop::journalnode```, make sure the
+```dfs_journalnode_edits_dir``` is partitioned and mounted on each of the hosts
+in ```journalnode_hosts```.
+
+When setting up a new cluster, you should ensure that your JournalNodes are up
+and running before your NameNodes.  When the NameNode is formatted for the first
+time, it will talk to the JournalNodes and tell them to initialize their shared
+edits directories.  If you are adding HA to an existing cluster, you will need
+to initialize your JournalNodes manually.  See section below on how to do this.
+
+You'll need to set two extra parameters on the ```cdh4::hadoop``` class on all
+your hadoop nodes, as well as specify the hosts of your standby NameNodes.
+
+```puppet
+
+class my::hadoop {
+    class { 'cdh4::hadoop':
+        nameservice_id      => 'mycluster',
+        namenode_hosts      => [
+            'namenode1.domain.org',
+            'namenode2.domain.org
+        ],
+        journalnode_hosts   => [
+            'datanode1.domain.org',
+            'datanode2.domain.org',
+            'datanode3.domain.org'
+        ],
+        datanode_mounts    => [
+            '/var/lib/hadoop/data/a',
+            '/var/lib/hadoop/data/b',
+            '/var/lib/hadoop/data/c'
+        ],
+        dfs_name_dir       => ['/var/lib/hadoop/name', '/mnt/hadoop_name'],
+    }
+}
+
+node 'hadoop-client.domain.org' {
+    include my::hadoop
+}
+```
+
+Note the differences from the non-HA setup:
+
+- An arbitrary ```nameservice_id``` has been specified.  This will be the
+logical name of your HDFS cluster.
+- Multiple ```namenode_hosts``` have been given.  You will need to include
+```cdh4::hadoop::namenode::standby``` on your standby NameNodes.
+- ```journalnode_hosts``` have been specified.
+
+On your standby NameNodes, instead of including ```cdh4::hadoop::master```,
+include ```cdh4::hadoop::namenode::standby```:
+
+``` puppet
+class my::hadoop::master inherits my::hadoop {
+    include cdh4::hadoop::master
+}
+class my::hadoop::standby inherits my::hadoop {
+    include cdh4::hadoop::namenode::standby
+}
+
+node 'namenode1.domain.org' {
+    include my::hadoop::master
+}
+
+node 'namenode2.domain.org' {
+    include my::hadoop::standby
+}
+```
+
+Including ```cdh4::hadoop::namenode::standby``` will bootstrap the standby
+NameNode from the primary NameNode and start the standby NameNode service.
+
+When are setting up brand new Hadoop cluster with HA, you should apply your
+puppet manifests to nodes in this order:
+
+1. JournalNodes
+2. Primary Hadoop master node (active NameNode)
+3. StandBy NameNodes
+4. Worker nodes (DataNodes)
+
+### Adding High Availability to a running cluster
+
+Go through all of the same steps as described in the above section.  Once all
+of your puppet manifests have been applied (JournalNodes running, NameNodes running and
+formatted/bootstrapped, etc.) you can initialize your
+JournalNodes' shared edit directories.
+
+```bash
+
+# Shutdown your HDFS cluster.  Everything will need a
+# restart on order to load the newly applied HA configs.
+# (Leave the JournalNodes running.)
+
+# On your hadoop master node:
+sudo service hadoop-yarn-resourcemanager stop
+sudo service hadoop-hdfs-namenode stop
+
+# On your hadoop worker nodes:
+sudo service hadoop-hdfs-datanode stop
+sudo service hadoop-yarn-nodemanager stop
+
+
+# Now run the following commands on your primary active NameNode.
+
+# initialize the JournalNodes' shared edit directories:
+sudo -u hdfs /usr/bin/hdfs namenode -initializeSharedEdits
+
+# Now restart your Hadoop master services
+
+# On your hadoop master node:
+sudo service hadoop-hdfs-namenode start
+sudo service hadoop-yarn-resourcemanager start
+
+# Now that your primary NameNode is back up, and
+# JournalNodes have been initialized, bootstrap
+# your Standby NameNode(s).  Run this command
+# on your standby NameNode(s):
+sudo -u hdfs /usr/bin/hdfs namenode -bootstrapStandby
+
+# On your hadoop worker nodes:
+sudo service hadoop-yarn-nodemanager start
+sudo service hadoop-hdfs-datanode start
+```
+
+*Note: replace 'hadoop-yarn-' services above with 'hadoop-0.20-mapreduce-' services if you are using MRv1 instead of YARN.*
+
+When there are multiple NameNodes and automatic failover is not configured
+(it is not yet supported by this puppet module), both NameNodes start up
+in standby mode.  You will have to manually transition one of them to active.
+
+```bash
+# on your hadoop master node:
+sudo -u hdfs /usr/bin/hdfs haadmin -transitionToActive <namenode_id>
+```
+
+```<namenode_id>``` will be the first entry in the ```$namenode_hosts``` array,
+with dot ('.') characters replaced with dashes ('-').  E.g.  ```namenode1-domain-org```.
+
+
+# Hive
+
+## Hive Clients
 
 ```puppet
 class { 'cdh4::hive':
@@ -90,7 +272,7 @@ class { 'cdh4::hive':
 }
 ```
 
-## For your Hive master node (hive-server2 and hive-metastore):
+## Hive Master (hive-server2 and hive-metastore)
 
 Include the same ```cdh4::hive``` class as indicated above, and then:
 
@@ -109,14 +291,15 @@ class { 'cdh4::hive::master':
 }
 ```
 
+# Oozie
 
-## For Oozie client nodes:
+## Oozie Clients
 
 ```puppet
 class { 'cdh4::oozie': }
 ```
 
-## For Oozie Server Nodes
+## Oozie Server
 
 The following will install and run oozie-server, as well as create a MySQL
 database for it to use. A MySQL database is the only currently supported
@@ -130,7 +313,8 @@ class { 'cdh4::oozie::server:
 }
 ```
 
-## Hue
+
+# Hue
 
 To install hue server, simply:
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,24 @@ Puppet module to install and manage components of
 Cloudera's Distribution 4 (CDH4) for Apache Hadoop.
 
 # Description
-Installs HDFS, YARN or MR1, Hive, Pig, Sqoop, Zookeeper, Oozie and
+
+Installs HDFS, YARN or MR1, Hive, HBase, Pig, Sqoop, Zookeeper, Oozie and
 Hue.  Note that, in order for this module to work, you will have to ensure
 that:
 
-* Sun JRE version 6 is installed.
-* Your package manager is configured with a repository containing the
+- Sun JRE version 6 or greater is installed
+- Your package manager is configured with a repository containing the
   Cloudera 4 packages.
 
-Note that many of the above mentioned services are not yet implemented in v0.2.
-See the v0.1 branch if you'd like to use these now.
+Notes:
+
+- This module has only been tested using CDH 4.2.1 on Ubuntu Precise 12.04.2 LTS
+- Many of the above mentioned services are not yet implemented in v0.2.
+  See the v0.1 branch if you'd like to use these now.
+
 
 # Installation:
+
 Clone (or copy) this repository into your puppet modules/cdh4 directory:
 ```bash
 git clone git://github.com/wikimedia/puppet-cdh4.git modules/cdh4
@@ -31,6 +37,7 @@ git submodule init && git submodule update
 # Usage
 
 ## For all Hadoop nodes:
+
 ```puppet
 
 include cdh4
@@ -54,6 +61,7 @@ points provided.
 If you would like to use MRv1 instead of YARN, set ```use_yarn``` to false.
 
 ## For your Hadoop master node:
+
 ```puppet
 include cdh4::hadoop::master
 ```
@@ -62,25 +70,38 @@ and set up ResourceManager and HistoryServer.  If using MRv1, this will install
 and set up the JobTracker.
 
 ### For your Hadoop worker nodes:
+
 ```puppet
 include cdh4::hadoop::worker
 ```
 
-This installs and starts up the DataNode.  If using YARN, this will install
-and set up the NodeManager.  If using MRv1, this will install and set up the
-TaskTracker.
+This installs and starts up the DataNode.  If using YARN, this will install and set up the NodeManager.  If using MRv1, this will install and set up the TaskTracker.
 
-# Notes:
+## For all Hive enabled nodes:
 
-## Coming Soon:
+```puppet
+class { 'cdh4::hive':
+  metastore_host  => 'hive-metastore-node.domain.org',
+  zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
+  jdbc_password   => $secret_password,
+}
+```
 
-- Hive
-- Oozie
-- Hue
+## For your Hive master node (hive-server2 and hive-metastore):
 
-## History:
+Include the same ```cdh4::hive``` class as indicated above, and then:
 
-The original version of this module has been moved to the v0.1 branch.
-It is currently more feature full than v0.2 under development in master.
-v0.1 is no longer supported, and soon master will contain the same features
-as v0.1.
+```puppet
+class { 'cdh4::hive::master': }
+```
+
+By default, a Hive metastore backend MySQL database will be used.  You must
+separately ensure that your $metastore_database (e.g. mysql) package is installed.
+If you want to disable automatic setup of your metastore backend
+database, set the ```metastore_database``` parameter to undef:
+
+```puppet
+class { 'cdh4::hive::master':
+  metastore_database => undef,
+}
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Puppet module to install and manage components of
 Cloudera's Distribution 4 (CDH4) for Apache Hadoop.
 
+NOTE: The main puppet-cdh4 repository is hosted in WMF Gerrit at
+[operations/puppet/cdh4](https://gerrit.wikimedia.org/r/#/admin/projects/operations/puppet/cdh4).
+
 # Description
 
 Installs HDFS, YARN or MR1, Hive, HBase, Pig, Sqoop, Zookeeper, Oozie and

--- a/README.md
+++ b/README.md
@@ -108,3 +108,24 @@ class { 'cdh4::hive::master':
   metastore_database => undef,
 }
 ```
+
+
+## For Oozie client nodes:
+
+```puppet
+class { 'cdh4::oozie': }
+```
+
+## For Oozie Server Nodes
+
+The following will install and run oozie-server, as well as create a MySQL
+database for it to use. A MySQL database is the only currently supported
+automatically installable backend database.  Alternatively, you may set
+```database => undef``` to avoid setting up MySQL and then configure your own
+Oozie database manually.
+
+```puppet
+class { 'cdh4::oozie::server:
+  jdbc_password -> $secret_password,
+}
+```

--- a/README.md
+++ b/README.md
@@ -129,3 +129,27 @@ class { 'cdh4::oozie::server:
   jdbc_password -> $secret_password,
 }
 ```
+
+## Hue
+
+To install hue server, simply:
+
+```puppet
+class { 'cdh4::hue':
+    secret_key => 'ii7nnoCGtP0wjub6nqnRfQx93YUV3iWG', # your secret key here.
+}
+```
+
+There are many more parameters to the ```cdh4::hue``` class.  See the class
+documentation in manifests/hue.pp.
+
+Note that while much of this puppet-cdh4 module supports MRv1, this Hue
+puppetization currently does not.  (Feel free to submit a patch to add
+MRv1 support though!)
+
+If you include ```cdh4::hive``` or ```cdh4::oozie``` classes on this node,
+Hue will be configured to run its Hive and Oozie apps.
+
+Hue Impala is not currently supported, since Impala hasn't been puppetized
+in this module yet.
+

--- a/README.md
+++ b/README.md
@@ -77,3 +77,10 @@ TaskTracker.
 - Hive
 - Oozie
 - Hue
+
+## History:
+
+The original version of this module has been moved to the v0.1 branch.
+It is currently more feature full than v0.2 under development in master.
+v0.1 is no longer supported, and soon master will contain the same features
+as v0.1.

--- a/README.md
+++ b/README.md
@@ -4,23 +4,26 @@ Puppet module to install and manage components of
 Cloudera's Distribution 4 (CDH4) for Apache Hadoop.
 
 # Description
-Installs HDFS, YARN or MR1, Hive, HBase, Pig, Sqoop, Zookeeper, Oozie and
+Installs HDFS, YARN or MR1, Hive, Pig, Sqoop, Zookeeper, Oozie and
 Hue.  Note that, in order for this module to work, you will have to ensure
 that:
 
-* Sun JRE version 6 or greater is installed
+* Sun JRE version 6 is installed.
 * Your package manager is configured with a repository containing the
   Cloudera 4 packages.
+
+Note that many of the above mentioned services are not yet implemented in v0.2.
+See the v0.1 branch if you'd like to use these now.
 
 # Installation:
 Clone (or copy) this repository into your puppet modules/cdh4 directory:
 ```bash
-git clone git://github.com/wikimedia/cloudera-cdh4-puppet.git modules/cdh4
+git clone git://github.com/wikimedia/puppet-cdh4.git modules/cdh4
 ```
 
 Or you could also use a git submodule:
 ```bash
-git submodule add git://github.com/wikimedia/operations-puppet-cdh4.git modules/cdh4
+git submodule add git://github.com/wikimedia/puppet-cdh4.git modules/cdh4
 git commit -m 'Adding modules/cdh4 as a git submodule.'
 git submodule init && git submodule update
 ```
@@ -54,11 +57,23 @@ If you would like to use MRv1 instead of YARN, set ```use_yarn``` to false.
 ```puppet
 include cdh4::hadoop::master
 ```
-This installs and starts up the NameNode.  If using YARN this will install and set up ResourceManager and HistoryServer.  If using MRv1, this will install and set up the JobTracker.
+This installs and starts up the NameNode.  If using YARN this will install
+and set up ResourceManager and HistoryServer.  If using MRv1, this will install
+and set up the JobTracker.
 
 ### For your Hadoop worker nodes:
 ```puppet
 include cdh4::hadoop::worker
 ```
 
-This installs and starts up the DataNode.  If using YARN, this will install and set up the NodeManager.  If using MRv1, this will install and set up the TaskTracker.
+This installs and starts up the DataNode.  If using YARN, this will install
+and set up the NodeManager.  If using MRv1, this will install and set up the
+TaskTracker.
+
+# Notes:
+
+## Coming Soon:
+
+- Hive
+- Oozie
+- Hue

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 ## Hadoop
 
-- Add hadoop-metrics2.properties configuration
 - Add hosts.exclude support for decommissioning nodes.
 - Change cluster (conf) name?  (use update-alternatives?)
 - Set default map/reduce tasks automatically based on facter node stats.
@@ -12,6 +11,7 @@
 - Support Secondary NameNode.
 - Support High Availability NameNode.
 - Make JMX ports configurable.
+- Make hadoop-metrics2.properties more configurable.
 
 ## Hive
 - Hive Server + Hive Metastore
@@ -24,3 +24,6 @@
 
 ## Zookeeper
 
+Won't implement. A Zookeeper package is available upstream in Debian/Ubuntu.
+Puppetization for this package can be found at
+https://github.com/wikimedia/operations-puppet-zookeeper

--- a/TODO.md
+++ b/TODO.md
@@ -15,8 +15,6 @@
 
 ## Oozie
 
-## Hue
-
 ## HBase
 
 ## Zookeeper

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,6 @@
 - Make JMX ports configurable.
 - Make hadoop-metrics2.properties more configurable.
 
-## Hive
-- Hive Server + Hive Metastore
-
 ## Oozie
 
 ## Hue

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,29 @@
+**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
+
+- [TODO:](#todo)
+    - [Hadoop](#hadoop)
+    - [HBase](#hbase)
+    - [Zookeeper](#zookeeper)
+
 # TODO:
 
 ## Hadoop
 
 - Add hosts.exclude support for decommissioning nodes.
 - Change cluster (conf) name?  (use update-alternatives?)
-- Set default map/reduce tasks automatically based on facter node stats.
+- Set default # map/reduce tasks automatically based on facter node stats.
 - Handle ensure => absent, especially for MRv1 vs YARN packages and services.
 - Implement standalone yarn proxyserver support.
 - Make log4j.properties more configurable.
 - Support Secondary NameNode.
-- Support High Availability NameNode.
 - Make JMX ports configurable.
 - Make hadoop-metrics2.properties more configurable.
-
-## Oozie
+- Support HA automatic failover.
+- HA NameNode Fencing support.
+- Rename 'use_yarn' parameter to 'yarn_enabled' for consistency.
 
 ## HBase
+- Implement.
 
 ## Zookeeper
 

--- a/files/hue/hue.init.d.sh
+++ b/files/hue/hue.init.d.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+
+# NOTE: This file is managed by Puppet.
+# This file has been modified by the wikimedia/puppet-cdh4 module.
+# It adds a --chuid flag to start-stop-daemon.  See the comment below,
+# and https://issues.cloudera.org/browse/HUE-1398 for more info.
+
+#
+# (c) Copyright 2011 Cloudera, Inc.
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+### BEGIN INIT INFO
+# Provides:          hue
+# Required-Start:    $network $local_fs
+# Required-Stop:
+# Should-Start:      $named
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Hue
+# Description:       Hue Web Interface
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+DAEMON=/usr/share/hue/build/env/bin/supervisor # Introduce the server's location here
+NAME=hue              			# Introduce the short server's name here
+DESC="Hue for Hadoop"                	# Introduce a short description here
+LOGDIR=/var/log/hue  			# Log directory to use
+
+PIDFILE=/var/run/hue/supervisor.pid
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+# Default options, these can be overriden by the information
+# at /etc/default/$NAME
+DAEMON_OPTS="-p $PIDFILE -d -l $LOGDIR" # Additional options given to the server
+
+DIETIME=10              # Time to wait for the server to die, in seconds
+                        # If this value is set too low you might not
+                        # let some servers to die gracefully and
+                        # 'restart' will not work
+
+STARTTIME=5             # Time to wait for the server to start, in seconds
+                        # If this value is set each time the server is
+                        # started (on start or restart) the script will
+                        # stall to try to determine if it is running
+                        # If it is not set and the server takes time
+                        # to setup a pid file the log message might
+                        # be a false positive (says it did not start
+                        # when it actually did)
+
+DAEMONUSER=hue     # Users to run the daemons as. If this value
+                        # is set start-stop-daemon will chuid the server
+
+# Include defaults if available
+if [ -f /etc/default/$NAME ] ; then
+    . /etc/default/$NAME
+fi
+
+# Use this if you want the user to explicitly set 'RUN' in
+# /etc/default/
+#if [ "x$RUN" != "xyes" ] ; then
+#    log_failure_msg "$NAME disabled, please adjust the configuration to your needs "
+#    log_failure_msg "and then set RUN to 'yes' in /etc/default/$NAME to enable it."
+#    exit 1
+#fi
+
+# Check that the user exists (if we set a user)
+# Does the user exist?
+if [ -n "$DAEMONUSER" ] ; then
+    if getent passwd | grep -q "^$DAEMONUSER:"; then
+        # Obtain the uid and gid
+        DAEMONUID=`getent passwd |grep "^$DAEMONUSER:" | awk -F : '{print $3}'`
+        DAEMONGID=`getent passwd |grep "^$DAEMONUSER:" | awk -F : '{print $4}'`
+    else
+        log_failure_msg "The user $DAEMONUSER, required to run $NAME does not exist."
+        exit 1
+    fi
+fi
+
+
+set -e
+
+running_pid() {
+# Check if a given process pid's cmdline matches a given name
+    pid=$1
+    [ -z "$pid" ] && return 1
+    [ ! -d /proc/$pid ] &&  return 1
+    cmd=`cat /proc/$pid/cmdline | tr "\000" "\n"|head -n 1 |cut -d : -f 1`
+    echo $cmd | grep -q python || return 1
+    return 0
+}
+
+running() {
+# Check if the process is running looking at /proc
+# (works for all users)
+
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    pid=`cat $PIDFILE`
+    running_pid $pid || return 1
+    return 0
+}
+
+start_server() {
+# Start the process using the wrapper
+	export PYTHON_EGG_CACHE='/tmp/.hue-python-eggs'
+        mkdir -p /usr/share/hue/pids/ 
+        mkdir -p ${PYTHON_EGG_CACHE}
+        mkdir -p $(dirname $PIDFILE) $LOGDIR
+        chown -R $DAEMONUSER $(dirname $PIDFILE) $LOGDIR ${PYTHON_EGG_CACHE}
+        # dont setuid, since supervisor will drop privileges on its
+        # own.
+        # start-stop-daemon --start --quiet --pidfile $PIDFILE \
+        #             --exec $DAEMON -- $DAEMON_OPTS
+
+        # ===== wikimedia/puppet-cdh4 patch =====
+        # THIS IS A BUG!  We need to honor $DAEMONUSER here.
+        # supervisor.py is smart enough to know what to do.
+        # See https://issues.cloudera.org/browse/HUE-1398.
+        # This init.d script will be removed when a newer
+        # version of hue (hopefully) fixes this.
+        start-stop-daemon --start --quiet --pidfile $PIDFILE \
+            --chuid $DAEMONUSER --exec $DAEMON -- $DAEMON_OPTS
+
+        errcode=$?
+        return $errcode
+}
+
+stop_server() {
+# Stop the process using the wrapper
+        killproc -p $PIDFILE $DAEMON
+        errcode=$?
+        return $errcode
+}
+
+reload_server() {
+    [ ! -f "$PIDFILE" ] && return 1
+    pid=pidofproc $PIDFILE # This is the daemon's pid
+    # Send a SIGHUP
+    kill -1 $pid
+    return $?
+}
+
+force_stop() {
+# Force the process to die killing it manually
+    [ ! -e "$PIDFILE" ] && return
+    if running ; then
+        kill -15 $pid
+        # Is it really dead?
+        sleep "$DIETIME"s
+        if running ; then
+            kill -9 $pid
+            sleep "$DIETIME"s
+            if running ; then
+                echo "Cannot kill $NAME (pid=$pid)!"
+                exit 1
+            fi
+        fi
+    fi
+    rm -f $PIDFILE
+}
+
+
+case "$1" in
+  start)
+        log_daemon_msg "Starting $DESC " "$NAME"
+        # Check if it's running first
+        if running ;  then
+            log_progress_msg "apparently already running"
+            log_end_msg 0
+            exit 0
+        fi
+        if start_server ; then
+            # NOTE: Some servers might die some time after they start,
+            # this code will detect this issue if STARTTIME is set
+            # to a reasonable value
+            [ -n "$STARTTIME" ] && sleep $STARTTIME # Wait some time
+            if  running ;  then
+                # It's ok, the server started and is running
+                log_end_msg 0
+            else
+                # It is not running after we did start
+                log_end_msg 1
+            fi
+        else
+            # Either we could not start it
+            log_end_msg 1
+        fi
+        ;;
+  stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        if running ; then
+            # Only stop the server if we see it running
+            errcode=0
+            stop_server || errcode=$?
+            log_end_msg $errcode
+        else
+            # If it's not running don't do anything
+            log_progress_msg "apparently not running"
+            log_end_msg 0
+            exit 0
+        fi
+        ;;
+  force-stop)
+        # First try to stop gracefully the program
+        $0 stop
+        errcode=0
+        if running; then
+            # If it's still running try to kill it more forcefully
+            log_daemon_msg "Stopping (force) $DESC" "$NAME"
+            force_stop || errcode=$?
+        fi
+        # if there are still processes running as hue, just kill them.
+        # we only do this if the user is hue, in case it's been changed
+        # to nobody - we don't want to go and kill a webserver
+        if [ "$DAEMONUSER" -eq hue ] && ps -u hue | grep -q build/env/bin ; then
+          killall -9 -u hue
+          errcode=$?
+        fi
+        log_end_msg $errcode
+        ;;
+  restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        errcode=0
+        stop_server || errcode=$?
+        # Wait some sensible amount, some server need this
+        [ -n "$DIETIME" ] && sleep $DIETIME
+        start_server || errcode=$?
+        [ -n "$STARTTIME" ] && sleep $STARTTIME
+        running || errcode=$?
+        log_end_msg $errcode
+        ;;
+  status)
+
+        log_daemon_msg "Checking status of $DESC" "$NAME"
+        if running ;  then
+            log_progress_msg "running"
+            log_end_msg 0
+        else
+            log_progress_msg "apparently not running"
+            log_end_msg 1
+            exit 1
+        fi
+        ;;
+  # Use this if the daemon cannot reload
+  reload)
+        log_warning_msg "Reloading $NAME daemon: not implemented, as the daemon"
+        log_warning_msg "cannot re-read the config file (use restart)."
+        ;;
+
+  *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|force-stop|restart|force-reload|status}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -37,6 +37,7 @@
 #   $yarn_nodemanager_resource_memory_mb
 #   $yarn_resourcemanager_scheduler_class - If you change this (e.g. to FairScheduler), you should also provide your own scheduler config .xml files outside of the cdh4 module.
 #   $use_yarn
+#   $ganglia_hosts                        - Set this to an array of ganglia host:ports if you want to enable ganglia sinks in hadoop-metrics2.properites
 #
 class cdh4::hadoop(
   $namenode_hostname,
@@ -64,7 +65,8 @@ class cdh4::hadoop(
   $mapreduce_final_compession              = $::cdh4::hadoop::defaults::mapreduce_final_compession,
   $yarn_nodemanager_resource_memory_mb     = $::cdh4::hadoop::defaults::yarn_nodemanager_resource_memory_mb,
   $yarn_resourcemanager_scheduler_class    = $::cdh4::hadoop::defaults::yarn_resourcemanager_scheduler_class,
-  $use_yarn                                = $::cdh4::hadoop::defaults::use_yarn
+  $use_yarn                                = $::cdh4::hadoop::defaults::use_yarn,
+  $ganglia_hosts                           = $::cdh4::hadoop::defaults::ganglia_hosts,
 
 ) inherits cdh4::hadoop::defaults
 {
@@ -128,5 +130,16 @@ class cdh4::hadoop(
   file { "${config_directory}/yarn-env.sh":
     ensure  => $yarn_ensure,
     content => template('cdh4/hadoop/yarn-env.sh.erb'),
+  }
+
+  # render hadoop-metrics2.properties
+  # if we hav Ganglia Hosts to send metrics to.
+  $hadoop_metrics2_ensure = $ganglia_hosts ? {
+      undef   => 'absent',
+      default => 'present',
+  }
+  file { "${config_directory}/hadoop-metrics2.properties":
+      ensure  => $hadoop_metrics2_ensure,
+      content => template('cdh4/hadoop/hadoop-metrics2.properties.erb'),
   }
 }

--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -40,106 +40,105 @@
 #   $ganglia_hosts                        - Set this to an array of ganglia host:ports if you want to enable ganglia sinks in hadoop-metrics2.properites
 #
 class cdh4::hadoop(
-  $namenode_hostname,
-  $dfs_name_dir,
-  $config_directory                        = $::cdh4::hadoop::defaults::config_directory,
-  $datanode_mounts                         = $::cdh4::hadoop::defaults::datanode_mounts,
-  $dfs_data_path                           = $::cdh4::hadoop::defaults::dfs_data_path,
-  $yarn_local_path                         = $::cdh4::hadoop::defaults::yarn_local_path,
-  $yarn_logs_path                          = $::cdh4::hadoop::defaults::yarn_logs_path,
-  $dfs_block_size                          = $::cdh4::hadoop::defaults::dfs_block_size,
-  $enable_jmxremote                        = $::cdh4::hadoop::defaults::enable_jmxremote,
-  $enable_webhdfs                          = $::cdh4::hadoop::defaults::enable_webhdfs,
-  $io_file_buffer_size                     = $::cdh4::hadoop::defaults::io_file_buffer_size,
-  $mapreduce_map_tasks_maximum             = $::cdh4::hadoop::defaults::mapreduce_map_tasks_maximum,
-  $mapreduce_reduce_tasks_maximum          = $::cdh4::hadoop::defaults::mapreduce_reduce_tasks_maximum,
-  $mapreduce_job_reuse_jvm_num_tasks       = $::cdh4::hadoop::defaults::mapreduce_job_reuse_jvm_num_tasks,
-  $mapreduce_reduce_shuffle_parallelcopies = $::cdh4::hadoop::defaults::mapreduce_reduce_shuffle_parallelcopies,
-  $mapreduce_map_memory_mb                 = $::cdh4::hadoop::defaults::mapreduce_map_memory_mb,
-  $mapreduce_reduce_memory_mb              = $::cdh4::hadoop::defaults::mapreduce_reduce_memory_mb,
-  $mapreduce_task_io_sort_mb               = $::cdh4::hadoop::defaults::mapreduce_task_io_sort_mb,
-  $mapreduce_task_io_sort_factor           = $::cdh4::hadoop::defaults::mapreduce_task_io_sort_factor,
-  $mapreduce_map_java_opts                 = $::cdh4::hadoop::defaults::mapreduce_map_java_opts,
-  $mapreduce_reduce_java_opts              = $::cdh4::hadoop::defaults::mapreduce_reduce_java_opts,
-  $mapreduce_intermediate_compression      = $::cdh4::hadoop::defaults::mapreduce_intermediate_compression,
-  $mapreduce_final_compession              = $::cdh4::hadoop::defaults::mapreduce_final_compession,
-  $yarn_nodemanager_resource_memory_mb     = $::cdh4::hadoop::defaults::yarn_nodemanager_resource_memory_mb,
-  $yarn_resourcemanager_scheduler_class    = $::cdh4::hadoop::defaults::yarn_resourcemanager_scheduler_class,
-  $use_yarn                                = $::cdh4::hadoop::defaults::use_yarn,
-  $ganglia_hosts                           = $::cdh4::hadoop::defaults::ganglia_hosts,
-
+    $namenode_hostname,
+    $dfs_name_dir,
+    $config_directory                        = $::cdh4::hadoop::defaults::config_directory,
+    $datanode_mounts                         = $::cdh4::hadoop::defaults::datanode_mounts,
+    $dfs_data_path                           = $::cdh4::hadoop::defaults::dfs_data_path,
+    $yarn_local_path                         = $::cdh4::hadoop::defaults::yarn_local_path,
+    $yarn_logs_path                          = $::cdh4::hadoop::defaults::yarn_logs_path,
+    $dfs_block_size                          = $::cdh4::hadoop::defaults::dfs_block_size,
+    $enable_jmxremote                        = $::cdh4::hadoop::defaults::enable_jmxremote,
+    $enable_webhdfs                          = $::cdh4::hadoop::defaults::enable_webhdfs,
+    $io_file_buffer_size                     = $::cdh4::hadoop::defaults::io_file_buffer_size,
+    $mapreduce_map_tasks_maximum             = $::cdh4::hadoop::defaults::mapreduce_map_tasks_maximum,
+    $mapreduce_reduce_tasks_maximum          = $::cdh4::hadoop::defaults::mapreduce_reduce_tasks_maximum,
+    $mapreduce_job_reuse_jvm_num_tasks       = $::cdh4::hadoop::defaults::mapreduce_job_reuse_jvm_num_tasks,
+    $mapreduce_reduce_shuffle_parallelcopies = $::cdh4::hadoop::defaults::mapreduce_reduce_shuffle_parallelcopies,
+    $mapreduce_map_memory_mb                 = $::cdh4::hadoop::defaults::mapreduce_map_memory_mb,
+    $mapreduce_reduce_memory_mb              = $::cdh4::hadoop::defaults::mapreduce_reduce_memory_mb,
+    $mapreduce_task_io_sort_mb               = $::cdh4::hadoop::defaults::mapreduce_task_io_sort_mb,
+    $mapreduce_task_io_sort_factor           = $::cdh4::hadoop::defaults::mapreduce_task_io_sort_factor,
+    $mapreduce_map_java_opts                 = $::cdh4::hadoop::defaults::mapreduce_map_java_opts,
+    $mapreduce_reduce_java_opts              = $::cdh4::hadoop::defaults::mapreduce_reduce_java_opts,
+    $mapreduce_intermediate_compression      = $::cdh4::hadoop::defaults::mapreduce_intermediate_compression,
+    $mapreduce_final_compession              = $::cdh4::hadoop::defaults::mapreduce_final_compession,
+    $yarn_nodemanager_resource_memory_mb     = $::cdh4::hadoop::defaults::yarn_nodemanager_resource_memory_mb,
+    $yarn_resourcemanager_scheduler_class    = $::cdh4::hadoop::defaults::yarn_resourcemanager_scheduler_class,
+    $use_yarn                                = $::cdh4::hadoop::defaults::use_yarn,
+    $ganglia_hosts                           = $::cdh4::hadoop::defaults::ganglia_hosts
 ) inherits cdh4::hadoop::defaults
 {
-  # JMX Ports
-  $namenode_jmxremote_port           = 9980
-  $datanode_jmxremote_port           = 9981
-  $secondary_namenode_jmxremote_port = 9982
-  $resourcemanager_jmxremote_port    = 9983
-  $nodemanager_jmxremote_port        = 9984
-  $proxyserver_jmxremote_port        = 9985
+    # JMX Ports
+    $namenode_jmxremote_port           = 9980
+    $datanode_jmxremote_port           = 9981
+    $secondary_namenode_jmxremote_port = 9982
+    $resourcemanager_jmxremote_port    = 9983
+    $nodemanager_jmxremote_port        = 9984
+    $proxyserver_jmxremote_port        = 9985
 
-  package { 'hadoop-client':
-    ensure => 'installed'
-  }
+    package { 'hadoop-client':
+        ensure => 'installed'
+    }
 
-  # All config files require hadoop-client package
-  File {
-    require => Package['hadoop-client']
-  }
+    # All config files require hadoop-client package
+    File {
+        require => Package['hadoop-client']
+    }
 
-  # ensure for yarn specific config files.
-  $yarn_ensure = $use_yarn ? {
-    false   => 'absent',
-    default => 'present',
-  }
+    # ensure for yarn specific config files.
+    $yarn_ensure = $use_yarn ? {
+        false   => 'absent',
+        default => 'present',
+    }
 
-  # Common hadoop config files
-  file { $config_directory:
-    ensure => 'directory',
-  }
+    # Common hadoop config files
+    file { $config_directory:
+        ensure => 'directory',
+    }
 
-  file { "${config_directory}/log4j.properties":
-    content => template('cdh4/hadoop/log4j.properties.erb'),
-  }
+    file { "${config_directory}/log4j.properties":
+        content => template('cdh4/hadoop/log4j.properties.erb'),
+    }
 
-  file { "${config_directory}/core-site.xml":
-    content => template('cdh4/hadoop/core-site.xml.erb'),
-  }
+    file { "${config_directory}/core-site.xml":
+        content => template('cdh4/hadoop/core-site.xml.erb'),
+    }
 
-  file { "$config_directory/hdfs-site.xml":
-    content => template('cdh4/hadoop/hdfs-site.xml.erb'),
-  }
+    file { "$config_directory/hdfs-site.xml":
+        content => template('cdh4/hadoop/hdfs-site.xml.erb'),
+    }
 
-  file {"$config_directory/httpfs-site.xml":
-    content => template('cdh4/hadoop/httpfs-site.xml.erb'),
-  }
+    file {"$config_directory/httpfs-site.xml":
+        content => template('cdh4/hadoop/httpfs-site.xml.erb'),
+    }
 
-  file { "${config_directory}/hadoop-env.sh":
-    content => template('cdh4/hadoop/hadoop-env.sh.erb'),
-  }
+    file { "${config_directory}/hadoop-env.sh":
+        content => template('cdh4/hadoop/hadoop-env.sh.erb'),
+    }
 
-  file { "${config_directory}/mapred-site.xml":
-    content => template('cdh4/hadoop/mapred-site.xml.erb'),
-  }
+    file { "${config_directory}/mapred-site.xml":
+        content => template('cdh4/hadoop/mapred-site.xml.erb'),
+    }
 
-  file { "${config_directory}/yarn-site.xml":
-    ensure  => $yarn_ensure,
-    content => template('cdh4/hadoop/yarn-site.xml.erb'),
-  }
+    file { "${config_directory}/yarn-site.xml":
+        ensure  => $yarn_ensure,
+        content => template('cdh4/hadoop/yarn-site.xml.erb'),
+    }
 
-  file { "${config_directory}/yarn-env.sh":
-    ensure  => $yarn_ensure,
-    content => template('cdh4/hadoop/yarn-env.sh.erb'),
-  }
+    file { "${config_directory}/yarn-env.sh":
+        ensure  => $yarn_ensure,
+        content => template('cdh4/hadoop/yarn-env.sh.erb'),
+    }
 
-  # render hadoop-metrics2.properties
-  # if we hav Ganglia Hosts to send metrics to.
-  $hadoop_metrics2_ensure = $ganglia_hosts ? {
-      undef   => 'absent',
-      default => 'present',
-  }
-  file { "${config_directory}/hadoop-metrics2.properties":
-      ensure  => $hadoop_metrics2_ensure,
-      content => template('cdh4/hadoop/hadoop-metrics2.properties.erb'),
-  }
+    # render hadoop-metrics2.properties
+    # if we hav Ganglia Hosts to send metrics to.
+    $hadoop_metrics2_ensure = $ganglia_hosts ? {
+        undef   => 'absent',
+        default => 'present',
+    }
+    file { "${config_directory}/hadoop-metrics2.properties":
+        ensure  => $hadoop_metrics2_ensure,
+        content => template('cdh4/hadoop/hadoop-metrics2.properties.erb'),
+    }
 }

--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -28,6 +28,7 @@
 #   $reduce_parallel_copies
 #   $map_memory_mb
 #   $reduce_memory_mb
+#   $mapreduce_system_dir
 #   $mapreduce_task_io_sort_mb
 #   $mapreduce_task_io_sort_factor
 #   $mapreduce_map_java_opts
@@ -51,6 +52,7 @@ class cdh4::hadoop(
     $enable_jmxremote                        = $::cdh4::hadoop::defaults::enable_jmxremote,
     $enable_webhdfs                          = $::cdh4::hadoop::defaults::enable_webhdfs,
     $io_file_buffer_size                     = $::cdh4::hadoop::defaults::io_file_buffer_size,
+    $mapreduce_system_dir                    = $::cdh4::hadoop::defaults::mapreduce_system_dir,
     $mapreduce_map_tasks_maximum             = $::cdh4::hadoop::defaults::mapreduce_map_tasks_maximum,
     $mapreduce_reduce_tasks_maximum          = $::cdh4::hadoop::defaults::mapreduce_reduce_tasks_maximum,
     $mapreduce_job_reuse_jvm_num_tasks       = $::cdh4::hadoop::defaults::mapreduce_job_reuse_jvm_num_tasks,

--- a/manifests/hadoop/datanode.pp
+++ b/manifests/hadoop/datanode.pp
@@ -11,9 +11,11 @@ class cdh4::hadoop::datanode {
 
     # install datanode daemon package
     service { 'hadoop-hdfs-datanode':
-        ensure  => 'running',
-        enable  => true,
-        alias   => 'datanode',
-        require => Package['hadoop-hdfs-datanode'],
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'datanode',
+        require    => Package['hadoop-hdfs-datanode'],
     }
 }

--- a/manifests/hadoop/datanode.pp
+++ b/manifests/hadoop/datanode.pp
@@ -2,18 +2,18 @@
 # Installs and starts up a Hadoop DataNode.
 #
 class cdh4::hadoop::datanode {
-  Class['cdh4::hadoop'] -> Class['cdh4::hadoop::datanode']
+    Class['cdh4::hadoop'] -> Class['cdh4::hadoop::datanode']
 
-  # install jobtracker daemon package
-  package { 'hadoop-hdfs-datanode':
-    ensure => 'installed'
-  }
+    # install jobtracker daemon package
+    package { 'hadoop-hdfs-datanode':
+        ensure => 'installed'
+    }
 
-  # install datanode daemon package
-  service { 'hadoop-hdfs-datanode':
-    ensure  => 'running',
-    enable  => true,
-    alias   => 'datanode',
-    require => Package['hadoop-hdfs-datanode'],
-  }
+    # install datanode daemon package
+    service { 'hadoop-hdfs-datanode':
+        ensure  => 'running',
+        enable  => true,
+        alias   => 'datanode',
+        require => Package['hadoop-hdfs-datanode'],
+    }
 }

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -3,6 +3,11 @@
 #
 class cdh4::hadoop::defaults {
     $config_directory                        = '/etc/hadoop/conf'
+
+    $nameservice_id                          = undef
+    $journalnode_hosts                       = undef
+    $dfs_journalnode_edits_dir               = undef
+
     $datanode_mounts                         = undef
     $dfs_data_path                           = 'hdfs/dn'
     $yarn_local_path                         = 'yarn/local'

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -26,4 +26,5 @@ class cdh4::hadoop::defaults {
   $yarn_nodemanager_resource_memory_mb     = undef
   $yarn_resourcemanager_scheduler_class    = undef
   $use_yarn                                = true
+  $ganglia_hosts                           = undef
 }

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -2,29 +2,29 @@
 # Default parameters for cdh4::hadoop configuration.
 #
 class cdh4::hadoop::defaults {
-  $config_directory                        = '/etc/hadoop/conf'
-  $datanode_mounts                         = undef
-  $dfs_data_path                           = 'hdfs/dn'
-  $yarn_local_path                         = 'yarn/local'
-  $yarn_logs_path                          = 'yarn/logs'
-  $dfs_block_size                          = 67108864 # 64MB default
-  $enable_jmxremote                        = true
-  $enable_webhdfs                          = true
-  $io_file_buffer_size                     = undef
-  $mapreduce_map_tasks_maximum             = undef
-  $mapreduce_reduce_tasks_maximum          = undef
-  $mapreduce_job_reuse_jvm_num_tasks       = undef
-  $mapreduce_reduce_shuffle_parallelcopies = undef
-  $mapreduce_map_memory_mb                 = undef
-  $mapreduce_reduce_memory_mb              = undef
-  $mapreduce_task_io_sort_mb               = undef
-  $mapreduce_task_io_sort_factor           = undef
-  $mapreduce_map_java_opts                 = undef
-  $mapreduce_reduce_java_opts              = undef
-  $mapreduce_intermediate_compression      = true
-  $mapreduce_final_compression             = false
-  $yarn_nodemanager_resource_memory_mb     = undef
-  $yarn_resourcemanager_scheduler_class    = undef
-  $use_yarn                                = true
-  $ganglia_hosts                           = undef
+    $config_directory                        = '/etc/hadoop/conf'
+    $datanode_mounts                         = undef
+    $dfs_data_path                           = 'hdfs/dn'
+    $yarn_local_path                         = 'yarn/local'
+    $yarn_logs_path                          = 'yarn/logs'
+    $dfs_block_size                          = 67108864 # 64MB default
+    $enable_jmxremote                        = true
+    $enable_webhdfs                          = true
+    $io_file_buffer_size                     = undef
+    $mapreduce_map_tasks_maximum             = undef
+    $mapreduce_reduce_tasks_maximum          = undef
+    $mapreduce_job_reuse_jvm_num_tasks       = undef
+    $mapreduce_reduce_shuffle_parallelcopies = undef
+    $mapreduce_map_memory_mb                 = undef
+    $mapreduce_reduce_memory_mb              = undef
+    $mapreduce_task_io_sort_mb               = undef
+    $mapreduce_task_io_sort_factor           = undef
+    $mapreduce_map_java_opts                 = undef
+    $mapreduce_reduce_java_opts              = undef
+    $mapreduce_intermediate_compression      = true
+    $mapreduce_final_compression             = false
+    $yarn_nodemanager_resource_memory_mb     = undef
+    $yarn_resourcemanager_scheduler_class    = undef
+    $use_yarn                                = true
+    $ganglia_hosts                           = undef
 }

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -10,6 +10,7 @@ class cdh4::hadoop::defaults {
     $dfs_block_size                          = 67108864 # 64MB default
     $enable_jmxremote                        = true
     $enable_webhdfs                          = true
+    $mapreduce_system_dir                    = undef
     $io_file_buffer_size                     = undef
     $mapreduce_map_tasks_maximum             = undef
     $mapreduce_reduce_tasks_maximum          = undef

--- a/manifests/hadoop/directory.pp
+++ b/manifests/hadoop/directory.pp
@@ -34,7 +34,7 @@ define cdh4::hadoop::directory (
   $group  = 'hdfs',
   $mode   = '0755')
 {
-  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Directory[$title]
+#  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Directory[$title]
 
   if $ensure == 'present' {
     exec { "cdh4::hadoop::directory ${title}":

--- a/manifests/hadoop/directory.pp
+++ b/manifests/hadoop/directory.pp
@@ -28,27 +28,27 @@
 # $mode   - HDFS diretory mode.  Default 0755
 #
 define cdh4::hadoop::directory (
-  $path   = $title,
-  $ensure = 'present',
-  $owner  = 'hdfs',
-  $group  = 'hdfs',
-  $mode   = '0755')
+    $path   = $title,
+    $ensure = 'present',
+    $owner  = 'hdfs',
+    $group  = 'hdfs',
+    $mode   = '0755')
 {
 #  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Directory[$title]
 
-  if $ensure == 'present' {
-    exec { "cdh4::hadoop::directory ${title}":
-      command => "/usr/bin/hadoop fs -mkdir ${path} && /usr/bin/hadoop fs -chmod ${mode} ${path} && /usr/bin/hadoop fs -chown ${owner}:${group} ${path}",
-      unless  => "/usr/bin/hadoop fs -test -e ${path}",
-      user    => 'hdfs',
+    if $ensure == 'present' {
+        exec { "cdh4::hadoop::directory ${title}":
+            command => "/usr/bin/hadoop fs -mkdir ${path} && /usr/bin/hadoop fs -chmod ${mode} ${path} && /usr/bin/hadoop fs -chown ${owner}:${group} ${path}",
+            unless  => "/usr/bin/hadoop fs -test -e ${path}",
+            user    => 'hdfs',
+        }
     }
-  }
-  else {
-    exec { "cdh4::hadoop::directory ${title}":
-      command => "/usr/bin/hadoop fs -rm -R ${path}",
-      onlyif  => "/usr/bin/hadoop fs -test -e ${path}",
-      user    => 'hdfs',
-      require => Service['hadoop-hdfs-namenode'],
+    else {
+        exec { "cdh4::hadoop::directory ${title}":
+            command => "/usr/bin/hadoop fs -rm -R ${path}",
+            onlyif  => "/usr/bin/hadoop fs -test -e ${path}",
+            user    => 'hdfs',
+            require => Service['hadoop-hdfs-namenode'],
+        }
     }
-  }
 }

--- a/manifests/hadoop/directory.pp
+++ b/manifests/hadoop/directory.pp
@@ -34,7 +34,7 @@ define cdh4::hadoop::directory (
     $group  = 'hdfs',
     $mode   = '0755')
 {
-#  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Directory[$title]
+  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Directory[$title]
 
     if $ensure == 'present' {
         exec { "cdh4::hadoop::directory ${title}":

--- a/manifests/hadoop/historyserver.pp
+++ b/manifests/hadoop/historyserver.pp
@@ -32,9 +32,12 @@ class cdh4::hadoop::historyserver {
     }
 
     service { 'hadoop-mapreduce-historyserver':
-        ensure    => 'running',
-        enable    => true,
-        alias     => 'historyserver',
-        require   => Package['hadoop-mapreduce-historyserver'],
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'historyserver',
+        require    => Package['hadoop-mapreduce-historyserver'],
+
     }
 }

--- a/manifests/hadoop/historyserver.pp
+++ b/manifests/hadoop/historyserver.pp
@@ -5,36 +5,36 @@
 # Hadoop node.
 #
 class cdh4::hadoop::historyserver {
-  Class['cdh4::hadoop::namenode'] -> Class['cdh4::hadoop::historyserver']
+    Class['cdh4::hadoop::namenode'] -> Class['cdh4::hadoop::historyserver']
 
-  if !$::cdh4::hadoop::use_yarn {
-    fail('Cannot use Hadoop YARN NodeManager if cdh4::hadoop::use_yarn is false.')
-  }
+    if !$::cdh4::hadoop::use_yarn {
+        fail('Cannot use Hadoop YARN NodeManager if cdh4::hadoop::use_yarn is false.')
+    }
 
-  # Create HistoryServer HDfS directories.
-  # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_4.html
-  cdh4::hadoop::directory { '/user/history':
-    # sudo -u hdfs hadoop fs -mkdir /user/history
-    # sudo -u hdfs hadoop fs -chmod -R 1777 /user/history
-    # sudo -u hdfs hadoop fs -chown yarn /user/history
-    owner   => 'yarn',
-    group   => 'hdfs',
-    mode    => '1777',
-    # Make sure HDFS directories are created before
-    # historyserver is installed and started, but after
-    # the namenode.
-    require => [Service['hadoop-hdfs-namenode'], Cdh4::Hadoop::Directory['/user']],
-  }
+    # Create HistoryServer HDfS directories.
+    # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_4.html
+    cdh4::hadoop::directory { '/user/history':
+        # sudo -u hdfs hadoop fs -mkdir /user/history
+        # sudo -u hdfs hadoop fs -chmod -R 1777 /user/history
+        # sudo -u hdfs hadoop fs -chown yarn /user/history
+        owner   => 'yarn',
+        group   => 'hdfs',
+        mode    => '1777',
+        # Make sure HDFS directories are created before
+        # historyserver is installed and started, but after
+        # the namenode.
+        require => [Service['hadoop-hdfs-namenode'], Cdh4::Hadoop::Directory['/user']],
+    }
 
-  package { 'hadoop-mapreduce-historyserver':
-    ensure  => 'installed',
-    require => Cdh4::Hadoop::Directory['/user/history'],
-  }
+    package { 'hadoop-mapreduce-historyserver':
+        ensure  => 'installed',
+        require => Cdh4::Hadoop::Directory['/user/history'],
+    }
 
-  service { 'hadoop-mapreduce-historyserver':
-    ensure    => 'running',
-    enable    => true,
-    alias     => 'historyserver',
-    require   => Package['hadoop-mapreduce-historyserver'],
-  }
+    service { 'hadoop-mapreduce-historyserver':
+        ensure    => 'running',
+        enable    => true,
+        alias     => 'historyserver',
+        require   => Package['hadoop-mapreduce-historyserver'],
+    }
 }

--- a/manifests/hadoop/historyserver.pp
+++ b/manifests/hadoop/historyserver.pp
@@ -38,6 +38,5 @@ class cdh4::hadoop::historyserver {
         hasrestart => true,
         alias      => 'historyserver',
         require    => Package['hadoop-mapreduce-historyserver'],
-
     }
 }

--- a/manifests/hadoop/jobtracker.pp
+++ b/manifests/hadoop/jobtracker.pp
@@ -98,6 +98,5 @@ class cdh4::hadoop::jobtracker {
         hasrestart => true,
         alias      => 'jobtracker',
         require    => Package['hadoop-0.20-mapreduce-jobtracker'],
-
     }
 }

--- a/manifests/hadoop/jobtracker.pp
+++ b/manifests/hadoop/jobtracker.pp
@@ -92,9 +92,12 @@ class cdh4::hadoop::jobtracker {
     }
 
     service { 'hadoop-0.20-mapreduce-jobtracker':
-        ensure  => 'running',
-        enable  => true,
-        alias   => 'jobtracker',
-        require => Package['hadoop-0.20-mapreduce-jobtracker'],
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'jobtracker',
+        require    => Package['hadoop-0.20-mapreduce-jobtracker'],
+
     }
 }

--- a/manifests/hadoop/jobtracker.pp
+++ b/manifests/hadoop/jobtracker.pp
@@ -5,96 +5,96 @@
 # Hadoop node.
 #
 class cdh4::hadoop::jobtracker {
-  Class['cdh4::hadoop::namenode'] -> Class['cdh4::hadoop::jobtracker']
+    Class['cdh4::hadoop::namenode'] -> Class['cdh4::hadoop::jobtracker']
 
-  if $::cdh4::hadoop::use_yarn {
-    fail('Cannot use Hadoop MRv1 JobTrackker if cdh4::hadoop::use_yarn is true.')
-  }
+    if $::cdh4::hadoop::use_yarn {
+        fail('Cannot use Hadoop MRv1 JobTrackker if cdh4::hadoop::use_yarn is true.')
+    }
 
-  # Create MRv1 directories.
-  # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_3.html
+    # Create MRv1 directories.
+    # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_3.html
 
-  # Make sure HDFS directories are created before
-  # jobtracker is installed and started, but after
-  # the namenode.
-  Cdh4::Hadoop::Directory {
-    before  => Package['hadoop-0.20-mapreduce-jobtracker'],
-    require => Service['hadoop-hdfs-namenode'],
-  }
+    # Make sure HDFS directories are created before
+    # jobtracker is installed and started, but after
+    # the namenode.
+    Cdh4::Hadoop::Directory {
+        before  => Package['hadoop-0.20-mapreduce-jobtracker'],
+        require => Service['hadoop-hdfs-namenode'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /tmp/mapred
-  # sudo -u hdfs hadoop fs -chown mapred:hadoop /tmp/mapred
-  # sudo -u hdfs hadoop fs -chmod 1777 /tmp/mapred
-  cdh4::hadoop::directory { '/tmp/mapred':
-    owner   => 'mapred',
-    group   => 'hadoop',
-    mode    => '1777',
-    require => Cdh4::Hadoop::Directory['/tmp'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /tmp/mapred
+    # sudo -u hdfs hadoop fs -chown mapred:hadoop /tmp/mapred
+    # sudo -u hdfs hadoop fs -chmod 1777 /tmp/mapred
+    cdh4::hadoop::directory { '/tmp/mapred':
+        owner   => 'mapred',
+        group   => 'hadoop',
+        mode    => '1777',
+        require => Cdh4::Hadoop::Directory['/tmp'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /tmp/mapred/system
-  # sudo -u hdfs hadoop fs -chown mapred:hadoop /tmp/mapred/system
-  # sudo -u hdfs hadoop fs -chmod 1777 /tmp/mapred/system
-  cdh4::hadoop::directory { '/tmp/mapred/system':
-    owner   => 'mapred',
-    group   => 'hadoop',
-    mode    => '1777',
-    require => Cdh4::Hadoop::Directory['/tmp/mapred'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /tmp/mapred/system
+    # sudo -u hdfs hadoop fs -chown mapred:hadoop /tmp/mapred/system
+    # sudo -u hdfs hadoop fs -chmod 1777 /tmp/mapred/system
+    cdh4::hadoop::directory { '/tmp/mapred/system':
+        owner   => 'mapred',
+        group   => 'hadoop',
+        mode    => '1777',
+        require => Cdh4::Hadoop::Directory['/tmp/mapred'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs
-  cdh4::hadoop::directory { '/var/lib/hadoop-hdfs':
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0755',
-    require => Cdh4::Hadoop::Directory['/var/lib'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs
+    cdh4::hadoop::directory { '/var/lib/hadoop-hdfs':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var/lib'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache
-  cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache':
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0755',
-    require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache
+    cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache/mapred
-  # sudo -u hdfs hadoop fs -chown mapred:hdfs /var/lib/hadoop-hdfs/cache/mapred
-  cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache/mapred':
-    owner   => 'mapred',
-    group   => 'hdfs',
-    mode    => '0755',
-    require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs/cache'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache/mapred
+    # sudo -u hdfs hadoop fs -chown mapred:hdfs /var/lib/hadoop-hdfs/cache/mapred
+    cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache/mapred':
+        owner   => 'mapred',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs/cache'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache/mapred/mapred
-  # sudo -u hdfs hadoop fs -chown mapred:hdfs /var/lib/hadoop-hdfs/cache/mapred/mapred
-  cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache/mapred/mapred':
-    owner   => 'mapred',
-    group   => 'hdfs',
-    mode    => '0755',
-    require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs/cache/mapred'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache/mapred/mapred
+    # sudo -u hdfs hadoop fs -chown mapred:hdfs /var/lib/hadoop-hdfs/cache/mapred/mapred
+    cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache/mapred/mapred':
+        owner   => 'mapred',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs/cache/mapred'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache/mapred/mapred/staging
-  # sudo -u hdfs hadoop fs -chown mapred:hdfs /var/lib/hadoop-hdfs/cache/mapred/mapred/staging
-  # sudo -u hdfs hadoop fs -chmod 1777 /var/lib/hadoop-hdfs/cache/mapred/mapred/staging
-  cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache/mapred/mapred/staging':
-    owner   => 'mapred',
-    group   => 'hdfs',
-    mode    => '1777',
-    require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs/cache/mapred/mapred'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var/lib/hadoop-hdfs/cache/mapred/mapred/staging
+    # sudo -u hdfs hadoop fs -chown mapred:hdfs /var/lib/hadoop-hdfs/cache/mapred/mapred/staging
+    # sudo -u hdfs hadoop fs -chmod 1777 /var/lib/hadoop-hdfs/cache/mapred/mapred/staging
+    cdh4::hadoop::directory { '/var/lib/hadoop-hdfs/cache/mapred/mapred/staging':
+        owner   => 'mapred',
+        group   => 'hdfs',
+        mode    => '1777',
+        require => Cdh4::Hadoop::Directory['/var/lib/hadoop-hdfs/cache/mapred/mapred'],
+    }
 
-  # install jobtracker daemon package
-  package { 'hadoop-0.20-mapreduce-jobtracker':
-    ensure  => 'installed',
-  }
+    # install jobtracker daemon package
+    package { 'hadoop-0.20-mapreduce-jobtracker':
+        ensure  => 'installed',
+    }
 
-  service { 'hadoop-0.20-mapreduce-jobtracker':
-    ensure  => 'running',
-    enable  => true,
-    alias   => 'jobtracker',
-    require => Package['hadoop-0.20-mapreduce-jobtracker'],
-  }
+    service { 'hadoop-0.20-mapreduce-jobtracker':
+        ensure  => 'running',
+        enable  => true,
+        alias   => 'jobtracker',
+        require => Package['hadoop-0.20-mapreduce-jobtracker'],
+    }
 }

--- a/manifests/hadoop/journalnode.pp
+++ b/manifests/hadoop/journalnode.pp
@@ -1,0 +1,29 @@
+# == Class cdh4::hadoop::journalnode
+#
+class cdh4::hadoop::journalnode {
+    Class['cdh4::hadoop'] -> Class['cdh4::hadoop::journalnode']
+
+    # install jobtracker daemon package
+    package { 'hadoop-hdfs-journalnode':
+        ensure => 'installed'
+    }
+
+    # Ensure that the journanode edits directory has the correct permissions.
+    file { $::cdh4::hadoop::dfs_journalnode_edits_dir:
+        ensure  => 'directory',
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Package['hadoop-hdfs-journalnode'],
+    }
+
+    # install datanode daemon package
+    service { 'hadoop-hdfs-journalnode':
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'journalnode',
+        require    => File[$::cdh4::hadoop::dfs_journalnode_edits_dir],
+    }
+}

--- a/manifests/hadoop/master.pp
+++ b/manifests/hadoop/master.pp
@@ -6,18 +6,18 @@
 # - JobTracker (MRv1).
 #
 class cdh4::hadoop::master {
-  Class['cdh4::hadoop'] -> Class['cdh4::hadoop::master']
+    Class['cdh4::hadoop'] -> Class['cdh4::hadoop::master']
 
-  include cdh4::hadoop::namenode
+    include cdh4::hadoop::namenode
 
-  # YARN uses ResourceManager and HistoryServer,
-  # NOT JobTracker.
-  if $::cdh4::hadoop::use_yarn {
-    include cdh4::hadoop::resourcemanager
-    include cdh4::hadoop::historyserver
-  }
-  # MRv1 just uses JobTracker
-  else {
-    include cdh4::hadoop::jobtracker
-  }
+    # YARN uses ResourceManager and HistoryServer,
+    # NOT JobTracker.
+    if $::cdh4::hadoop::use_yarn {
+        include cdh4::hadoop::resourcemanager
+        include cdh4::hadoop::historyserver
+    }
+    # MRv1 just uses JobTracker
+    else {
+        include cdh4::hadoop::jobtracker
+    }
 }

--- a/manifests/hadoop/master.pp
+++ b/manifests/hadoop/master.pp
@@ -8,7 +8,7 @@
 class cdh4::hadoop::master {
     Class['cdh4::hadoop'] -> Class['cdh4::hadoop::master']
 
-    include cdh4::hadoop::namenode
+    include cdh4::hadoop::namenode::primary
 
     # YARN uses ResourceManager and HistoryServer,
     # NOT JobTracker.

--- a/manifests/hadoop/namenode.pp
+++ b/manifests/hadoop/namenode.pp
@@ -5,100 +5,100 @@
 # a common HDFS directory hierarchy.
 #
 class cdh4::hadoop::namenode {
-  Class['cdh4::hadoop'] -> Class['cdh4::hadoop::namenode']
+    Class['cdh4::hadoop'] -> Class['cdh4::hadoop::namenode']
 
-  # install namenode daemon package
-  package { 'hadoop-hdfs-namenode':
-    ensure => installed
-  }
+    # install namenode daemon package
+    package { 'hadoop-hdfs-namenode':
+        ensure => installed
+    }
 
-  file { "${::cdh4::hadoop::config_directory}/hosts.exclude":
-    ensure  => 'present',
-    require => Package['hadoop-hdfs-namenode'],
-  }
+    file { "${::cdh4::hadoop::config_directory}/hosts.exclude":
+        ensure  => 'present',
+        require => Package['hadoop-hdfs-namenode'],
+    }
 
-  # Ensure that the namenode directory has the correct permissions.
-  file { $::cdh4::hadoop::dfs_name_dir:
-    ensure  => 'directory',
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0700',
-    require => Package['hadoop-hdfs-namenode'],
-  }
+    # Ensure that the namenode directory has the correct permissions.
+    file { $::cdh4::hadoop::dfs_name_dir:
+        ensure  => 'directory',
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0700',
+        require => Package['hadoop-hdfs-namenode'],
+    }
 
-  # If $dfs_name_dir/current/VERSION doesn't exist, assume
-  # NameNode has not been formated.  Format it before
-  # the namenode service is started.
-  # Note: $dfs_name_dir might be an array.
-  #       We only want to check the first entry.
-  $dfs_name_dir      = $::cdh4::hadoop::dfs_name_dir
-  $dfs_name_dir_main = inline_template('<%= (dfs_name_dir.class == Array) ? dfs_name_dir[0] : dfs_name_dir %>')
-  exec { 'hadoop-namenode-format':
-    command => '/usr/bin/hdfs namenode -format',
-    creates => "${dfs_name_dir_main}/current/VERSION",
-    user    => 'hdfs',
-    require => File[$::cdh4::hadoop::dfs_name_dir],
-  }
+    # If $dfs_name_dir/current/VERSION doesn't exist, assume
+    # NameNode has not been formated.  Format it before
+    # the namenode service is started.
+    # Note: $dfs_name_dir might be an array.
+    #       We only want to check the first entry.
+    $dfs_name_dir      = $::cdh4::hadoop::dfs_name_dir
+    $dfs_name_dir_main = inline_template('<%= (dfs_name_dir.class == Array) ? dfs_name_dir[0] : dfs_name_dir %>')
+    exec { 'hadoop-namenode-format':
+        command => '/usr/bin/hdfs namenode -format',
+        creates => "${dfs_name_dir_main}/current/VERSION",
+        user    => 'hdfs',
+        require => File[$::cdh4::hadoop::dfs_name_dir],
+    }
 
-  service { 'hadoop-hdfs-namenode':
-    ensure  => 'running',
-    enable  => true,
-    alias   => 'namenode',
-    require => [File["${::cdh4::hadoop::config_directory}/hosts.exclude"], Exec['hadoop-namenode-format']],
-  }
+    service { 'hadoop-hdfs-namenode':
+        ensure  => 'running',
+        enable  => true,
+        alias   => 'namenode',
+        require => [File["${::cdh4::hadoop::config_directory}/hosts.exclude"], Exec['hadoop-namenode-format']],
+    }
 
-  # Create common HDFS directories.
-  # Make sure NameNode is running before we try to create these.
-  Cdh4::Hadoop::Directory {
-    require => Service['hadoop-hdfs-namenode'],
-  }
+    # Create common HDFS directories.
+    # Make sure NameNode is running before we try to create these.
+    Cdh4::Hadoop::Directory {
+        require => Service['hadoop-hdfs-namenode'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /tmp
-  # sudo -u hdfs hadoop fs -chmod 1777 /tmp
-  cdh4::hadoop::directory { '/tmp':
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '1777',
-  }
+    # sudo -u hdfs hadoop fs -mkdir /tmp
+    # sudo -u hdfs hadoop fs -chmod 1777 /tmp
+    cdh4::hadoop::directory { '/tmp':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '1777',
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /user
-  # sudo -u hdfs hadoop fs -chmod 0775 /user
-  # sudo -u hdfs hadoop fs -chown hdfs:hadoop /user
-  cdh4::hadoop::directory { '/user':
-    owner   => 'hdfs',
-    group   => 'hadoop',
-    mode    => '0775',
-  }
+    # sudo -u hdfs hadoop fs -mkdir /user
+    # sudo -u hdfs hadoop fs -chmod 0775 /user
+    # sudo -u hdfs hadoop fs -chown hdfs:hadoop /user
+    cdh4::hadoop::directory { '/user':
+        owner   => 'hdfs',
+        group   => 'hadoop',
+        mode    => '0775',
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /user/hdfs
-  cdh4::hadoop::directory { '/user/hdfs':
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0755',
-    require => Cdh4::Hadoop::Directory['/user'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /user/hdfs
+    cdh4::hadoop::directory { '/user/hdfs':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/user'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var
-  cdh4::hadoop::directory { '/var':
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0755',
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var
+    cdh4::hadoop::directory { '/var':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var/lib
-  cdh4::hadoop::directory { '/var/lib':
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0755',
-    require => Cdh4::Hadoop::Directory['/var'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var/lib
+    cdh4::hadoop::directory { '/var/lib':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var'],
+    }
 
-  # sudo -u hdfs hadoop fs -mkdir /var/log
-  cdh4::hadoop::directory { '/var/log':
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0755',
-    require => Cdh4::Hadoop::Directory['/var'],
-  }
+    # sudo -u hdfs hadoop fs -mkdir /var/log
+    cdh4::hadoop::directory { '/var/log':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var'],
+    }
 
 }

--- a/manifests/hadoop/namenode.pp
+++ b/manifests/hadoop/namenode.pp
@@ -56,32 +56,33 @@ class cdh4::hadoop::namenode {
   # sudo -u hdfs hadoop fs -mkdir /tmp
   # sudo -u hdfs hadoop fs -chmod 1777 /tmp
   cdh4::hadoop::directory { '/tmp':
-    owner => 'hdfs',
-    group => 'hdfs',
-    mode  => '1777',
+    owner   => 'hdfs',
+    group   => 'hdfs',
+    mode    => '1777',
   }
 
   # sudo -u hdfs hadoop fs -mkdir /user
   # sudo -u hdfs hadoop fs -chmod 0775 /user
   # sudo -u hdfs hadoop fs -chown hdfs:hadoop /user
   cdh4::hadoop::directory { '/user':
-    owner => 'hdfs',
-    group => 'hadoop',
-    mode  => '0775',
+    owner   => 'hdfs',
+    group   => 'hadoop',
+    mode    => '0775',
   }
 
   # sudo -u hdfs hadoop fs -mkdir /user/hdfs
   cdh4::hadoop::directory { '/user/hdfs':
-    owner => 'hdfs',
-    group => 'hdfs',
-    mode  => '0755',
+    owner   => 'hdfs',
+    group   => 'hdfs',
+    mode    => '0755',
+    require => Cdh4::Hadoop::Directory['/user'],
   }
 
   # sudo -u hdfs hadoop fs -mkdir /var
   cdh4::hadoop::directory { '/var':
-    owner => 'hdfs',
-    group => 'hdfs',
-    mode  => '0755',
+    owner   => 'hdfs',
+    group   => 'hdfs',
+    mode    => '0755',
   }
 
   # sudo -u hdfs hadoop fs -mkdir /var/lib

--- a/manifests/hadoop/namenode.pp
+++ b/manifests/hadoop/namenode.pp
@@ -4,6 +4,10 @@
 # already formatted.  It will also create
 # a common HDFS directory hierarchy.
 #
+# Note:  If you are using HA NameNode (indicated by setting
+# cdh4::hadoop::nameservice_id), your JournalNodes should be running before
+# this class is applied.
+#
 class cdh4::hadoop::namenode {
     Class['cdh4::hadoop'] -> Class['cdh4::hadoop::namenode']
 
@@ -29,13 +33,9 @@ class cdh4::hadoop::namenode {
     # If $dfs_name_dir/current/VERSION doesn't exist, assume
     # NameNode has not been formated.  Format it before
     # the namenode service is started.
-    # Note: $dfs_name_dir might be an array.
-    #       We only want to check the first entry.
-    $dfs_name_dir      = $::cdh4::hadoop::dfs_name_dir
-    $dfs_name_dir_main = inline_template('<%= (dfs_name_dir.class == Array) ? dfs_name_dir[0] : dfs_name_dir %>')
     exec { 'hadoop-namenode-format':
         command => '/usr/bin/hdfs namenode -format',
-        creates => "${dfs_name_dir_main}/current/VERSION",
+        creates => "${::cdh4::hadoop::dfs_name_dir_main}/current/VERSION",
         user    => 'hdfs',
         require => File[$::cdh4::hadoop::dfs_name_dir],
     }
@@ -48,59 +48,4 @@ class cdh4::hadoop::namenode {
         alias      => 'namenode',
         require    => [File["${::cdh4::hadoop::config_directory}/hosts.exclude"], Exec['hadoop-namenode-format']],
     }
-
-    # Create common HDFS directories.
-    # Make sure NameNode is running before we try to create these.
-    Cdh4::Hadoop::Directory {
-        require => Service['hadoop-hdfs-namenode'],
-    }
-
-    # sudo -u hdfs hadoop fs -mkdir /tmp
-    # sudo -u hdfs hadoop fs -chmod 1777 /tmp
-    cdh4::hadoop::directory { '/tmp':
-        owner   => 'hdfs',
-        group   => 'hdfs',
-        mode    => '1777',
-    }
-
-    # sudo -u hdfs hadoop fs -mkdir /user
-    # sudo -u hdfs hadoop fs -chmod 0775 /user
-    # sudo -u hdfs hadoop fs -chown hdfs:hadoop /user
-    cdh4::hadoop::directory { '/user':
-        owner   => 'hdfs',
-        group   => 'hadoop',
-        mode    => '0775',
-    }
-
-    # sudo -u hdfs hadoop fs -mkdir /user/hdfs
-    cdh4::hadoop::directory { '/user/hdfs':
-        owner   => 'hdfs',
-        group   => 'hdfs',
-        mode    => '0755',
-        require => Cdh4::Hadoop::Directory['/user'],
-    }
-
-    # sudo -u hdfs hadoop fs -mkdir /var
-    cdh4::hadoop::directory { '/var':
-        owner   => 'hdfs',
-        group   => 'hdfs',
-        mode    => '0755',
-    }
-
-    # sudo -u hdfs hadoop fs -mkdir /var/lib
-    cdh4::hadoop::directory { '/var/lib':
-        owner   => 'hdfs',
-        group   => 'hdfs',
-        mode    => '0755',
-        require => Cdh4::Hadoop::Directory['/var'],
-    }
-
-    # sudo -u hdfs hadoop fs -mkdir /var/log
-    cdh4::hadoop::directory { '/var/log':
-        owner   => 'hdfs',
-        group   => 'hdfs',
-        mode    => '0755',
-        require => Cdh4::Hadoop::Directory['/var'],
-    }
-
 }

--- a/manifests/hadoop/namenode.pp
+++ b/manifests/hadoop/namenode.pp
@@ -41,10 +41,12 @@ class cdh4::hadoop::namenode {
     }
 
     service { 'hadoop-hdfs-namenode':
-        ensure  => 'running',
-        enable  => true,
-        alias   => 'namenode',
-        require => [File["${::cdh4::hadoop::config_directory}/hosts.exclude"], Exec['hadoop-namenode-format']],
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'namenode',
+        require    => [File["${::cdh4::hadoop::config_directory}/hosts.exclude"], Exec['hadoop-namenode-format']],
     }
 
     # Create common HDFS directories.

--- a/manifests/hadoop/namenode/primary.pp
+++ b/manifests/hadoop/namenode/primary.pp
@@ -1,0 +1,89 @@
+# == Class cdh4::hadoop::namenode::primary
+# Hadoop Primary NameNode.
+#
+# This class is applied by cdh4::hadoop::master even
+# if we aren't using HA Standby Namenodes.  The primary NameNode will be inferred
+# as the first entry $cdh4::hadoop::namenode_hosts variable.  If we are using
+# HA, then the primary NameNode will be transitioned to active as once NameNode
+# has been formatted, before common HDFS directories are created.
+#
+class cdh4::hadoop::namenode::primary inherits cdh4::hadoop::namenode {
+    # Go ahead and transision this primary namenode to active if we are using HA.
+    if ($::cdh4::hadoop::ha_enabled) {
+        $primary_namenode_id = $::cdh4::hadoop::primary_namenode_id
+
+        exec { 'haaadmin-transitionToActive':
+            # $namenode_id is set in parent cdh4::hadoop::namenode class.
+            command     => "/usr/bin/hdfs haadmin -transitionToActive ${primary_namenode_id}",
+            unless      => "/usr/bin/hdfs haadmin -getServiceState    ${primary_namenode_id} | /bin/grep -q active",
+            user        => 'hdfs',
+            # Only run this command if the namenode was just formatted
+            # and after the namenode has started up.
+            refreshonly => true,
+            subscribe   => Exec['hadoop-namenode-format'],
+            require     => Service['hadoop-hdfs-namenode'],
+        }
+        # Make sure NameNode is running and active
+        # before we try to create common HDFS directories.
+        Cdh4::Hadoop::Directory {
+            require => Exec['haaadmin-transitionToActive'],
+        }
+    }
+    else {
+        # Make sure NameNode is running
+        # before we try to create common HDFS directories.
+        Cdh4::Hadoop::Directory {
+            require =>  Service['hadoop-hdfs-namenode'],
+        }
+    }
+
+    # Create common HDFS directories.
+
+    # sudo -u hdfs hadoop fs -mkdir /tmp
+    # sudo -u hdfs hadoop fs -chmod 1777 /tmp
+    cdh4::hadoop::directory { '/tmp':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '1777',
+    }
+
+    # sudo -u hdfs hadoop fs -mkdir /user
+    # sudo -u hdfs hadoop fs -chmod 0775 /user
+    # sudo -u hdfs hadoop fs -chown hdfs:hadoop /user
+    cdh4::hadoop::directory { '/user':
+        owner   => 'hdfs',
+        group   => 'hadoop',
+        mode    => '0775',
+    }
+
+    # sudo -u hdfs hadoop fs -mkdir /user/hdfs
+    cdh4::hadoop::directory { '/user/hdfs':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/user'],
+    }
+
+    # sudo -u hdfs hadoop fs -mkdir /var
+    cdh4::hadoop::directory { '/var':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+    }
+
+    # sudo -u hdfs hadoop fs -mkdir /var/lib
+    cdh4::hadoop::directory { '/var/lib':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var'],
+    }
+
+    # sudo -u hdfs hadoop fs -mkdir /var/log
+    cdh4::hadoop::directory { '/var/log':
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
+        require => Cdh4::Hadoop::Directory['/var'],
+    }
+}

--- a/manifests/hadoop/namenode/standby.pp
+++ b/manifests/hadoop/namenode/standby.pp
@@ -1,0 +1,23 @@
+# == Class cdh4::hadoop::namenode::standby
+# Hadoop Standby NameNode.  Include this class instead of
+# cdh4::hadoop::master on your HA standby NameNode(s).  This
+# will bootstrap the standby dfs.name.dir with the contents
+# from your primary active NameNode.
+#
+# See README.md for more documentation.
+#
+# NOTE: Your JournalNodes should be running before this class is applied.
+#
+class cdh4::hadoop::namenode::standby inherits cdh4::hadoop::namenode {
+    # Fail if nameservice_id isn't set.
+    if (!$::cdh4::hadoop::ha_enabled) {
+        fail('Cannot use Standby NameNode in a non HA setup.  Set $nameservice_id on the cdh4::hadoop class to enable HA.')
+    }
+
+    # Override the namenode -format command to bootstrap this
+    # standby NameNode's dfs.name.dir with the data from the
+    # active NameNode.
+    Exec['hadoop-namenode-format'] {
+        command     => '/usr/bin/hdfs namenode -bootstrapStandby',
+    }
+}

--- a/manifests/hadoop/nodemanager.pp
+++ b/manifests/hadoop/nodemanager.pp
@@ -2,21 +2,21 @@
 # Installs and configures a Hadoop NodeManager worker node.
 #
 class cdh4::hadoop::nodemanager {
-  Class['cdh4::hadoop'] -> Class['cdh4::hadoop::nodemanager']
+    Class['cdh4::hadoop'] -> Class['cdh4::hadoop::nodemanager']
 
-  if !$::cdh4::hadoop::use_yarn {
-    fail('Cannot use Hadoop YARN NodeManager if cdh4::hadoop::use_yarn is false.')
-  }
+    if !$::cdh4::hadoop::use_yarn {
+        fail('Cannot use Hadoop YARN NodeManager if cdh4::hadoop::use_yarn is false.')
+    }
 
-  package { ['hadoop-yarn-nodemanager', 'hadoop-mapreduce']:
-    ensure => 'installed',
-  }
+    package { ['hadoop-yarn-nodemanager', 'hadoop-mapreduce']:
+        ensure => 'installed',
+    }
 
-  # NodeManager (YARN TaskTracker)
-  service { 'hadoop-yarn-nodemanager':
-    ensure  => 'running',
-    enable  => true,
-    alias   => 'nodemanager',
-    require => [Package['hadoop-yarn-nodemanager', 'hadoop-mapreduce']],
-  }
+    # NodeManager (YARN TaskTracker)
+    service { 'hadoop-yarn-nodemanager':
+        ensure  => 'running',
+        enable  => true,
+        alias   => 'nodemanager',
+        require => [Package['hadoop-yarn-nodemanager', 'hadoop-mapreduce']],
+    }
 }

--- a/manifests/hadoop/nodemanager.pp
+++ b/manifests/hadoop/nodemanager.pp
@@ -14,9 +14,12 @@ class cdh4::hadoop::nodemanager {
 
     # NodeManager (YARN TaskTracker)
     service { 'hadoop-yarn-nodemanager':
-        ensure  => 'running',
-        enable  => true,
-        alias   => 'nodemanager',
-        require => [Package['hadoop-yarn-nodemanager', 'hadoop-mapreduce']],
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'nodemanager',
+        require    => [Package['hadoop-yarn-nodemanager', 'hadoop-mapreduce']],
     }
 }
+

--- a/manifests/hadoop/resourcemanager.pp
+++ b/manifests/hadoop/resourcemanager.pp
@@ -3,35 +3,35 @@
 # This will create YARN HDFS directories.
 #
 class cdh4::hadoop::resourcemanager {
-  Class['cdh4::hadoop::namenode'] -> Class['cdh4::hadoop::resourcemanager']
+    Class['cdh4::hadoop::namenode'] -> Class['cdh4::hadoop::resourcemanager']
 
-  if !$::cdh4::hadoop::use_yarn  {
-    fail('Cannot use Hadoop YARN ResourceManager if cdh4::hadoop::use_yarn is false.')
-  }
+    if !$::cdh4::hadoop::use_yarn  {
+        fail('Cannot use Hadoop YARN ResourceManager if cdh4::hadoop::use_yarn is false.')
+    }
 
-  # Create YARN HDFS directories.
-  # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_4.html
-  cdh4::hadoop::directory { '/var/log/hadoop-yarn':
-    # sudo -u hdfs hadoop fs -mkdir /var/log/hadoop-yarn
-    # sudo -u hdfs hadoop fs -chown yarn:mapred /var/log/hadoop-yarn
-    owner   => 'yarn',
-    group   => 'mapred',
-    mode    => '0755',
-    # Make sure HDFS directories are created before
-    # resourcemanager is installed and started, but after
-    # the namenode.
-    require => [Service['hadoop-hdfs-namenode'], Cdh4::Hadoop::Directory['/var/log']],
-  }
+    # Create YARN HDFS directories.
+    # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_4.html
+    cdh4::hadoop::directory { '/var/log/hadoop-yarn':
+        # sudo -u hdfs hadoop fs -mkdir /var/log/hadoop-yarn
+        # sudo -u hdfs hadoop fs -chown yarn:mapred /var/log/hadoop-yarn
+        owner   => 'yarn',
+        group   => 'mapred',
+        mode    => '0755',
+        # Make sure HDFS directories are created before
+        # resourcemanager is installed and started, but after
+        # the namenode.
+        require => [Service['hadoop-hdfs-namenode'], Cdh4::Hadoop::Directory['/var/log']],
+    }
 
-  package { 'hadoop-yarn-resourcemanager':
-    ensure  => 'installed',
-    require => Cdh4::Hadoop::Directory['/var/log/hadoop-yarn'],
-  }
+    package { 'hadoop-yarn-resourcemanager':
+        ensure  => 'installed',
+        require => Cdh4::Hadoop::Directory['/var/log/hadoop-yarn'],
+    }
 
-  service { 'hadoop-yarn-resourcemanager':
-    ensure  => 'running',
-    enable  => true,
-    alias   => 'resourcemanager',
-    require => Package['hadoop-yarn-resourcemanager'],
-  }
+    service { 'hadoop-yarn-resourcemanager':
+        ensure  => 'running',
+        enable  => true,
+        alias   => 'resourcemanager',
+        require => Package['hadoop-yarn-resourcemanager'],
+    }
 }

--- a/manifests/hadoop/resourcemanager.pp
+++ b/manifests/hadoop/resourcemanager.pp
@@ -29,9 +29,11 @@ class cdh4::hadoop::resourcemanager {
     }
 
     service { 'hadoop-yarn-resourcemanager':
-        ensure  => 'running',
-        enable  => true,
-        alias   => 'resourcemanager',
-        require => Package['hadoop-yarn-resourcemanager'],
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'resourcemanager',
+        require    => Package['hadoop-yarn-resourcemanager'],
     }
 }

--- a/manifests/hadoop/tasktracker.pp
+++ b/manifests/hadoop/tasktracker.pp
@@ -13,9 +13,11 @@ class cdh4::hadoop::tasktracker {
     }
 
     service { 'hadoop-0.20-mapreduce-tasktracker':
-        ensure  => 'running',
-        enable  => true,
-        alias   => 'tasktracker',
-        require => Package['hadoop-0.20-mapreduce-tasktracker'],
+        ensure     => 'running',
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        alias      => 'tasktracker',
+        require    => Package['hadoop-0.20-mapreduce-tasktracker'],
     }
 }

--- a/manifests/hadoop/tasktracker.pp
+++ b/manifests/hadoop/tasktracker.pp
@@ -1,21 +1,21 @@
 # == Class cdh4::hadoop::tasktracker
 # Installs and configures Hadoop MRv1 TaskTracker.
 class cdh4::hadoop::tasktracker {
-  Class['cdh4::hadoop'] -> Class['cdh4::hadoop::tasktracker']
+    Class['cdh4::hadoop'] -> Class['cdh4::hadoop::tasktracker']
 
-  if $::cdh4::hadoop::use_yarn {
-    fail('Cannot use Hadoop MRv1 JobTrackker if cdh4::hadoop::use_yarn is true.')
-  }
+    if $::cdh4::hadoop::use_yarn {
+        fail('Cannot use Hadoop MRv1 JobTrackker if cdh4::hadoop::use_yarn is true.')
+    }
 
-  # install tasktracker daemon package
-  package { 'hadoop-0.20-mapreduce-tasktracker':
-    ensure => 'installed'
-  }
+    # install tasktracker daemon package
+    package { 'hadoop-0.20-mapreduce-tasktracker':
+        ensure => 'installed'
+    }
 
-  service { 'hadoop-0.20-mapreduce-tasktracker':
-    ensure  => 'running',
-    enable  => true,
-    alias   => 'tasktracker',
-    require => Package['hadoop-0.20-mapreduce-tasktracker'],
-  }
+    service { 'hadoop-0.20-mapreduce-tasktracker':
+        ensure  => 'running',
+        enable  => true,
+        alias   => 'tasktracker',
+        require => Package['hadoop-0.20-mapreduce-tasktracker'],
+    }
 }

--- a/manifests/hadoop/worker.pp
+++ b/manifests/hadoop/worker.pp
@@ -12,24 +12,24 @@
 # manage them.
 #
 class cdh4::hadoop::worker {
-  Class['cdh4::hadoop'] -> Class['cdh4::hadoop::worker']
+    Class['cdh4::hadoop'] -> Class['cdh4::hadoop::worker']
 
-  cdh4::hadoop::worker::paths { $::cdh4::hadoop::datanode_mounts: }
+    cdh4::hadoop::worker::paths { $::cdh4::hadoop::datanode_mounts: }
 
-  class { 'cdh4::hadoop::datanode':
-    require => Cdh4::Hadoop::Worker::Paths[$::cdh4::hadoop::datanode_mounts],
-  }
-
-  # YARN uses NodeManager.
-  if $::cdh4::hadoop::use_yarn {
-    class { 'cdh4::hadoop::nodemanager':
-      require => Cdh4::Hadoop::Worker::Paths[$::cdh4::hadoop::datanode_mounts],
+    class { 'cdh4::hadoop::datanode':
+        require => Cdh4::Hadoop::Worker::Paths[$::cdh4::hadoop::datanode_mounts],
     }
-  }
-  # MRv1 uses TaskTracker.
-  else {
-    class { 'cdh4::hadoop::tasktracker':
-      require => Cdh4::Hadoop::Worker::Paths[$::cdh4::hadoop::datanode_mounts],
+
+    # YARN uses NodeManager.
+    if $::cdh4::hadoop::use_yarn {
+        class { 'cdh4::hadoop::nodemanager':
+            require => Cdh4::Hadoop::Worker::Paths[$::cdh4::hadoop::datanode_mounts],
+        }
     }
-  }
+    # MRv1 uses TaskTracker.
+    else {
+        class { 'cdh4::hadoop::tasktracker':
+            require => Cdh4::Hadoop::Worker::Paths[$::cdh4::hadoop::datanode_mounts],
+        }
+    }
 }

--- a/manifests/hadoop/worker/paths.pp
+++ b/manifests/hadoop/worker/paths.pp
@@ -34,49 +34,49 @@
 # (If you use MRv1 instead of yarn, the hierarchy will be slightly different.)
 #
 define cdh4::hadoop::worker::paths($basedir = $title) {
-  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Worker::Paths[$title]
+    Class['cdh4::hadoop'] -> Cdh4::Hadoop::Worker::Paths[$title]
 
-  # hdfs, hadoop, and yarn users
-  # are all added by packages
-  # installed by cdh4::hadoop
+    # hdfs, hadoop, and yarn users
+    # are all added by packages
+    # installed by cdh4::hadoop
 
-  # make sure mounts exist
-  file { $basedir:
-    ensure  => 'directory',
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0755',
-  }
-
-  # Assume that $dfs_data_path is two levels.  e.g. hdfs/dn
-  # We need to manage the parent directory too.
-  $dfs_data_path_parent = inline_template("<%= File.dirname('${::cdh4::hadoop::dfs_data_path}') %>")
-  # create DataNode directories
-  file { ["${basedir}/${dfs_data_path_parent}", "${basedir}/${::cdh4::hadoop::dfs_data_path}"]:
-    ensure  => 'directory',
-    owner   => 'hdfs',
-    group   => 'hdfs',
-    mode    => '0700',
-    require => File[$basedir],
-  }
-
-  if $::cdh4::hadoop::use_yarn {
-    # create yarn local directories
-    file { ["${basedir}/yarn", "${basedir}/yarn/local", "${basedir}/yarn/logs"]:
-      ensure  => 'directory',
-      owner   => 'yarn',
-      group   => 'yarn',
-      mode    => '0755',
+    # make sure mounts exist
+    file { $basedir:
+        ensure  => 'directory',
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0755',
     }
-  }
-  else {
-    # Create MRv1 local directories.
-    # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_3.html
-    file { ["${basedir}/mapred", "${basedir}/mapred/local"]:
-      ensure  => 'directory',
-      owner   => 'mapred',
-      group   => 'hadoop',
-      mode    => '0755',
+
+    # Assume that $dfs_data_path is two levels.  e.g. hdfs/dn
+    # We need to manage the parent directory too.
+    $dfs_data_path_parent = inline_template("<%= File.dirname('${::cdh4::hadoop::dfs_data_path}') %>")
+    # create DataNode directories
+    file { ["${basedir}/${dfs_data_path_parent}", "${basedir}/${::cdh4::hadoop::dfs_data_path}"]:
+        ensure  => 'directory',
+        owner   => 'hdfs',
+        group   => 'hdfs',
+        mode    => '0700',
+        require => File[$basedir],
     }
-  }
+
+    if $::cdh4::hadoop::use_yarn {
+        # create yarn local directories
+        file { ["${basedir}/yarn", "${basedir}/yarn/local", "${basedir}/yarn/logs"]:
+            ensure  => 'directory',
+            owner   => 'yarn',
+            group   => 'yarn',
+            mode    => '0755',
+        }
+    }
+    else {
+        # Create MRv1 local directories.
+        # See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_11_3.html
+        file { ["${basedir}/mapred", "${basedir}/mapred/local"]:
+            ensure  => 'directory',
+            owner   => 'mapred',
+            group   => 'hadoop',
+            mode    => '0755',
+        }
+    }
 }

--- a/manifests/hbase.pp
+++ b/manifests/hbase.pp
@@ -1,0 +1,18 @@
+# == Class cdh4::hbase
+#
+# Installs HBase packages needed for server and region-servers
+#
+class cdh4::hbase(
+  $root_dir         = $::cdh4::hbase::defaults::root_dir,
+  $config_directory = $::cdh4::hbase::defaults::config_directory,
+  $master_domain    = $::cdh4::hbase::defaults::master_domain,
+) inherits cdh4::hbase::defaults 
+{
+  package { 'hbase':
+    ensure => 'installed',
+  }
+
+  file { "${config_directory}/hbase-site.xml":
+    content => template('cdh4/hbase/hbase-site.xml.erb'),
+  }
+}

--- a/manifests/hbase.pp
+++ b/manifests/hbase.pp
@@ -6,6 +6,7 @@ class cdh4::hbase(
   $root_dir         = $::cdh4::hbase::defaults::root_dir,
   $config_directory = $::cdh4::hbase::defaults::config_directory,
   $master_domain    = $::cdh4::hbase::defaults::master_domain,
+  $zookeeper_master = $::cdh4::hbase::defaults::zookeeper_master,
 ) inherits cdh4::hbase::defaults 
 {
   package { 'hbase':

--- a/manifests/hbase.pp
+++ b/manifests/hbase.pp
@@ -2,16 +2,24 @@
 #
 # Installs HBase packages needed for server and region-servers
 #
+# == Parameters
+#   $rootdir            - HBase root directory in HDFS
+#   $config_directory   - Path of the HBase config directory
+#   $zookeeper_hosts    - Array of Zookeeper hostnames 
+#
 class cdh4::hbase(
-  $root_dir         = $::cdh4::hbase::defaults::root_dir,
+  $rootdir          = $::cdh4::hbase::defaults::rootdir,
   $config_directory = $::cdh4::hbase::defaults::config_directory,
-  $master_domain    = $::cdh4::hbase::defaults::master_domain,
-  $zookeeper_master = $::cdh4::hbase::defaults::zookeeper_master,
+  $zookeeper_hosts  = $::cdh4::hbase::defaults::zookeeper_master,
 ) inherits cdh4::hbase::defaults 
 {
+  Class['cdh4::hadoop'] -> Class['cdh4::hbase']
+ 
   package { 'hbase':
     ensure => 'installed',
   }
+
+  $namenode_host = $::cdh4::hadoop::primary_namenode_host
 
   file { "${config_directory}/hbase-site.xml":
     content => template('cdh4/hbase/hbase-site.xml.erb'),

--- a/manifests/hbase/defaults.pp
+++ b/manifests/hbase/defaults.pp
@@ -1,0 +1,8 @@
+# == Class cdh4::hbase::defaults
+# Default parameters for cdh4::hbase configuration.
+#
+class cdh4::hbase::defaults {
+  $root_dir         = '/hbase'
+  $config_directory = '/etc/hbase/conf'
+  $master_domain    = undef
+}

--- a/manifests/hbase/defaults.pp
+++ b/manifests/hbase/defaults.pp
@@ -5,4 +5,5 @@ class cdh4::hbase::defaults {
   $root_dir         = '/hbase'
   $config_directory = '/etc/hbase/conf'
   $master_domain    = undef
+  $zookeeper_master = undef
 }

--- a/manifests/hbase/defaults.pp
+++ b/manifests/hbase/defaults.pp
@@ -2,8 +2,7 @@
 # Default parameters for cdh4::hbase configuration.
 #
 class cdh4::hbase::defaults {
-  $root_dir         = '/hbase'
+  $rootdir         = '/hbase'
   $config_directory = '/etc/hbase/conf'
-  $master_domain    = undef
-  $zookeeper_master = undef
+  $zookeeper_hosts = undef
 }

--- a/manifests/hbase/master.pp
+++ b/manifests/hbase/master.pp
@@ -1,0 +1,27 @@
+# == Class cdh4::hbase::master
+# Installs HBase master
+#
+class cdh4::hbase::master {
+
+  Class['cdh4::hbase'] -> Class['cdh4::hbase::master']
+
+  package { 'hbase-master': 
+    ensure => 'installed',
+  }
+
+  service { 'hbase-master':
+    ensure      => 'running',
+    enable      => true,
+    hasrestart  => true,
+    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+    subscribe   => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+  }
+
+  # sudo -u hdfs hadoop fs -mkdir /hbase
+  # sudo -u hdfs hadoop fs -chown hbase /hbase
+  cdh4::hadoop::directory { "${::cdh4::hbase::root_dir}":
+    owner   => 'hbase',
+    group   => 'hbase',
+  }
+
+}

--- a/manifests/hbase/master.pp
+++ b/manifests/hbase/master.pp
@@ -13,6 +13,7 @@ class cdh4::hbase::master {
     ensure      => 'running',
     enable      => true,
     hasrestart  => true,
+    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"], 
   }
 
   # sudo -u hdfs hadoop fs -mkdir /hbase

--- a/manifests/hbase/master.pp
+++ b/manifests/hbase/master.pp
@@ -13,13 +13,11 @@ class cdh4::hbase::master {
     ensure      => 'running',
     enable      => true,
     hasrestart  => true,
-    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
-    subscribe   => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
   }
 
   # sudo -u hdfs hadoop fs -mkdir /hbase
   # sudo -u hdfs hadoop fs -chown hbase /hbase
-  cdh4::hadoop::directory { "${::cdh4::hbase::root_dir}":
+  cdh4::hadoop::directory { "${::cdh4::hbase::rootdir}":
     owner   => 'hbase',
     group   => 'hbase',
   }

--- a/manifests/hbase/regionserver.pp
+++ b/manifests/hbase/regionserver.pp
@@ -1,0 +1,20 @@
+# == Class cdh4::hbase::master
+# Installs HBase regionserver
+#
+class cdh4::hbase::regionserver {
+
+  Class['cdh4::hbase'] -> Class['cdh4::hbase::regionserver']
+
+  package { 'hbase-regionserver': 
+    ensure => 'installed',
+  }
+
+  service { 'hbase-regionserver':
+    ensure      => 'running',
+    enable      => true,
+    hasrestart  => true,
+    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+    subscribe   => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+  }
+
+}

--- a/manifests/hbase/regionserver.pp
+++ b/manifests/hbase/regionserver.pp
@@ -13,8 +13,6 @@ class cdh4::hbase::regionserver {
     ensure      => 'running',
     enable      => true,
     hasrestart  => true,
-    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
-    subscribe   => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
   }
 
 }

--- a/manifests/hbase/regionserver.pp
+++ b/manifests/hbase/regionserver.pp
@@ -13,6 +13,7 @@ class cdh4::hbase::regionserver {
     ensure      => 'running',
     enable      => true,
     hasrestart  => true,
+    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"], 
   }
 
 }

--- a/manifests/hive.pp
+++ b/manifests/hive.pp
@@ -15,6 +15,7 @@
 # $jdbc_username                 - Metastore JDBC username.  Default: hive
 # $jdbc_password                 - Metastore JDBC password.  Default: hive
 # $jdbc_host                     - Metastore JDBC hostname.  Default: localhost
+# $jdbc_port                     - Metastore JDBC port.      Default: 3306
 # $jdbc_driver                   - Metastore JDBC driver class name.
 #                                  Default: org.apache.derby.jdbc.EmbeddedDriver
 # $jdbc_protocol                 - Metastore JDBC protocol.  Default: mysql
@@ -47,6 +48,7 @@ class cdh4::hive(
     $jdbc_username               = $cdh4::hive::defaults::jdbc_username,
     $jdbc_password               = $cdh4::hive::defaults::jdbc_password,
     $jdbc_host                   = $cdh4::hive::defaults::jdbc_host,
+    $jdbc_port                   = $cdh4::hive::defaults::jdbc_port,
     $jdbc_driver                 = $cdh4::hive::defaults::jdbc_driver,
     $jdbc_protocol               = $cdh4::hive::defaults::jdbc_protocol,
 

--- a/manifests/hive.pp
+++ b/manifests/hive.pp
@@ -78,6 +78,8 @@ class cdh4::hive(
     file { '/etc/hive/conf/hive-site.xml':
         content => template($hive_site_template),
         mode    => $hive_site_mode,
+        owner   => 'hive',
+        group   => 'hive',
         require => Package['hive'],
     }
     file { '/etc/hive/conf/hive-exec-log4j.properties':

--- a/manifests/hive.pp
+++ b/manifests/hive.pp
@@ -4,7 +4,7 @@
 # Use cdh4::hive::server to install and set up a Hive server.
 #
 class cdh4::hive {
-  package { 'hive':
-    ensure => 'installed',
-  }
+    package { 'hive':
+        ensure => 'installed',
+    }
 }

--- a/manifests/hive.pp
+++ b/manifests/hive.pp
@@ -1,10 +1,86 @@
 # == Class cdh4::hive
 #
 # Installs Hive packages (needed for Hive Client).
-# Use cdh4::hive::server to install and set up a Hive server.
+# Use this in conjunction with cdh4::hive::master to install and set up a
+# Hive Server and Hive Metastore.
 #
-class cdh4::hive {
+# == Parameters
+# $metastore_host                - fqdn of the metastore host
+# $zookeeper_hosts               - Array of zookeeper hostname/IP(:port)s.
+#                                  Default: undef (zookeeper lock management
+#                                  will not be used).
+#
+# $jdbc_database                 - Metastore JDBC database name.
+#                                  Default: 'hive_metastore'
+# $jdbc_username                 - Metastore JDBC username.  Default: hive
+# $jdbc_password                 - Metastore JDBC password.  Default: hive
+# $jdbc_host                     - Metastore JDBC hostname.  Default: localhost
+# $jdbc_driver                   - Metastore JDBC driver class name.
+#                                  Default: org.apache.derby.jdbc.EmbeddedDriver
+# $jdbc_protocol                 - Metastore JDBC protocol.  Default: mysql
+#
+# $exec_parallel_thread_number   - Number of jobs at most can be executed in parallel.
+#                                  Set this to 0 to disable parallel execution.
+# $optimize_skewjoin             - Enable or disable skew join optimization.
+#                                  Default: false
+# $skewjoin_key                  - Number of rows where skew join is used.
+#                                - Default: 10000
+# $skewjoin_mapjoin_map_tasks    - Number of map tasks used in the follow up
+#                                  map join jobfor a skew join.   Default: 10000.
+# $skewjoin_mapjoin_min_split    - Skew join minimum split size.  Default: 33554432
+#
+# $stats_enabled                 - Enable or disable temp Hive stats.  Default: false
+# $stats_dbclass                 - The default database class that stores
+#                                  temporary hive statistics.  Default: jdbc:derby
+# $stats_jdbcdriver              - JDBC driver for the database that stores
+#                                  temporary hive statistics.
+#                                  Default: org.apache.derby.jdbc.EmbeddedDriver
+# $stats_dbconnectionstring      - Connection string for the database that stores
+#                                  temporary hive statistics.
+#                                  Default: jdbc:derby:;databaseName=TempStatsStore;create=true
+#
+class cdh4::hive(
+    $metastore_host,
+    $zookeeper_hosts             = $cdh4::hive::defaults::zookeeper_hosts,
+
+    $jdbc_database               = $cdh4::hive::defaults::jdbc_database,
+    $jdbc_username               = $cdh4::hive::defaults::jdbc_username,
+    $jdbc_password               = $cdh4::hive::defaults::jdbc_password,
+    $jdbc_host                   = $cdh4::hive::defaults::jdbc_host,
+    $jdbc_driver                 = $cdh4::hive::defaults::jdbc_driver,
+    $jdbc_protocol               = $cdh4::hive::defaults::jdbc_protocol,
+
+    $exec_parallel_thread_number = $cdh4::hive::defaults::exec_parallel_thread_number,
+    $optimize_skewjoin           = $cdh4::hive::defaults::optimize_skewjoin,
+    $skewjoin_key                = $cdh4::hive::defaults::skewjoin_key,
+    $skewjoin_mapjoin_map_tasks  = $cdh4::hive::defaults::skewjoin_mapjoin_map_tasks,
+
+    $stats_enabled               = $cdh4::hive::defaults::stats_enabled,
+    $stats_dbclass               = $cdh4::hive::defaults::stats_dbclass,
+    $stats_jdbcdriver            = $cdh4::hive::defaults::stats_jdbcdriver,
+    $stats_dbconnectionstring    = $cdh4::hive::defaults::stats_dbconnectionstring,
+
+    $hive_site_template          = $cdh4::hive::defaults::hive_site_template,
+    $hive_exec_log4j_template    = $cdh4::hive::defaults::hive_exec_log4j_template
+) inherits cdh4::hive::defaults
+{
     package { 'hive':
         ensure => 'installed',
+    }
+
+    # Make sure hive-site.xml is not world readable on the
+    # metastore host.  On the metastore host, hive-site.xml
+    # will contain database connection credentials.
+    $hive_site_mode = $metastore_host ? {
+        $::fqdn => '0440',
+        default => '0444',
+    }
+    file { '/etc/hive/conf/hive-site.xml':
+        content => template($hive_site_template),
+        mode    => $hive_site_mode,
+        require => Package['hive'],
+    }
+    file { '/etc/hive/conf/hive-exec-log4j.properties':
+        content => template($hive_exec_log4j_template),
     }
 }

--- a/manifests/hive/defaults.pp
+++ b/manifests/hive/defaults.pp
@@ -1,0 +1,32 @@
+# == Class hive::defaults
+# Default Hive configs
+#
+class cdh4::hive::defaults {
+    $zookeeper_hosts             = undef
+
+    $jdbc_driver                 = 'org.apache.derby.jdbc.EmbeddedDriver'
+    $jdbc_protocol               = 'mysql'
+    $jdbc_database               = 'hive_metastore'
+    $jdbc_host                   = 'localhost'
+    $jdbc_port                   = 3306
+    $jdbc_username               = 'hive'
+    $jdbc_password               = 'hive'
+
+    $exec_parallel_thread_number = 8  # set this to 0 to disable hive.exec.parallel
+    $optimize_skewjoin           = false
+    $skewjoin_key                = 10000
+    $skewjoin_mapjoin_map_tasks  = 10000
+    $skewjoin_mapjoin_min_split  = 33554432
+
+    $stats_enabled               = false
+    $stats_dbclass               = 'jdbc:derby'
+    $stats_jdbcdriver            = 'org.apache.derby.jdbc.EmbeddedDriver'
+    $stats_dbconnectionstring    = 'jdbc:derby:;databaseName=TempStatsStore;create=true'
+
+    # Default puppet paths to template config files.
+    # This allows us to use custom template config files
+    # if we want to override more settings than this
+    # module yet supports.
+    $hive_site_template          = 'cdh4/hive/hive-site.xml.erb'
+    $hive_exec_log4j_template    = 'cdh4/hive/hive-exec-log4j.properties.erb'
+}

--- a/manifests/hive/defaults.pp
+++ b/manifests/hive/defaults.pp
@@ -4,7 +4,7 @@
 class cdh4::hive::defaults {
     $zookeeper_hosts             = undef
 
-    $jdbc_driver                 = 'org.apache.derby.jdbc.EmbeddedDriver'
+    $jdbc_driver                 = 'com.mysql.jdbc.Driver'
     $jdbc_protocol               = 'mysql'
     $jdbc_database               = 'hive_metastore'
     $jdbc_host                   = 'localhost'

--- a/manifests/hive/master.pp
+++ b/manifests/hive/master.pp
@@ -1,0 +1,31 @@
+# == Class cdh4::hive::master
+# Wrapper class for hive::server, hive::metastore, and hive::metastore::* databases.
+#
+# Include this class on your Hive master node with $metastore_database
+# set to one of the available metastore backend classes in the hive/metastore/
+# directory.  If you want to set up a hive metastore database backend that
+# is not supported here, you may set $metastore_databse to undef.
+#
+# You must separately ensure that your $metastore_database (e.g. mysql) package
+# is installed.
+#
+# == Parameters
+# $metastore_database - Name of metastore database to use.  This should be
+#                       the name of a cdh4::hive::metastore::* class in
+#                       hive/metastore/*.pp.
+#
+class cdh4::hive::master($metastore_database = 'mysql') {
+    class { 'cdh4::hive::server':    }
+    class { 'cdh4::hive::metastore': }
+
+    # Set up the metastore database by including
+    # the $metastore_database_class.
+    $metastore_database_class = "cdh4::hive::metastore::${metastore_database}"
+    if ($metastore_database) {
+        class { $metastore_database_class: }
+    }
+
+    # Make sure the $metastore_database_class is included and set up
+    # before we start the hive-metastore service
+    Class[$metastore_database_class] -> Class['cdh4::hive::metastore']
+}

--- a/manifests/hive/metastore.pp
+++ b/manifests/hive/metastore.pp
@@ -1,0 +1,17 @@
+# == Class cdh4::hive::metastore
+#
+class cdh4::hive::metastore
+{
+    Class['cdh4::hive'] -> Class['cdh4::hive::metastore']
+
+    package { 'hive-metastore':
+        ensure => 'installed',
+    }
+
+    service { 'hive-metastore':
+        ensure     => 'running',
+        require    => Package['hive-metastore'],
+        hasrestart => true,
+        hasstatus  => true,
+    }
+}

--- a/manifests/hive/metastore/mysql.pp
+++ b/manifests/hive/metastore/mysql.pp
@@ -1,0 +1,57 @@
+# == Class cdh4::hive::metastore::mysql
+# Configures and sets up a MySQL metastore for Hive.
+#
+# Note that this class does not support running
+# the Metastore database on a different host than where your
+# hive-metastore service will run.  Permissions will only be granted
+# for localhost MySQL users, so hive-metastore must run on this node.
+#
+# Also, root must be able to run /usr/bin/mysql with no password and have permissions
+# to create databases and users and grant permissions.
+#
+# See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/latest/CDH4-Installation-Guide/cdh4ig_hive_metastore_configure.html
+#
+# == Parameters
+# $schema_version - When installing the metastore database, this version of
+#                   the schema will be created.  This must match an .sql file
+#                   schema version found in /usr/lib/hive/scripts/metastore/upgrade/mysql.
+#                   Default: 0.10.0
+#
+class cdh4::hive::metastore::mysql($schema_version = '0.10.0') {
+    Class['cdh4::hive'] -> Class['cdh4::hive::metastore::mysql']
+
+    if (!defined(Package['libmysql-java'])) {
+        package { 'libmysql-java':
+            ensure => 'installed',
+        }
+    }
+    # symlink the mysql.jar into /var/lib/hive/lib
+    file { '/usr/lib/hive/lib/libmysql-java.jar':
+        ensure  => 'link',
+        target  => '/usr/share/java/mysql.jar',
+        require => Package['libmysql-java'],
+    }
+
+    $db_name = $cdh4::hive::jdbc_database
+    $db_user = $cdh4::hive::jdbc_username
+    $db_pass = $cdh4::hive::jdbc_password
+
+    # hive is going to need an hive database and user.
+    exec { 'hive_mysql_create_database':
+        command => "/usr/bin/mysql -e \"
+CREATE DATABASE ${db_name}; USE ${db_name};
+SOURCE /usr/lib/hive/scripts/metastore/upgrade/mysql/hive-schema-${schema_version}.mysql.sql;\"",
+        unless  => "/usr/bin/mysql -e 'SHOW DATABASES' | /bin/grep -q ${db_name}",
+        user    => 'root',
+    }
+    exec { 'hive_mysql_create_user':
+        command => "/usr/bin/mysql -e \"
+CREATE USER '${db_user}'@'localhost' IDENTIFIED BY '${db_pass}';
+CREATE USER '${db_user}'@'127.0.0.1' IDENTIFIED BY '${db_pass}';
+GRANT ALL PRIVILEGES ON ${db_name}.* TO '${db_user}'@'localhost' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON ${db_name}.* TO '${db_user}'@'127.0.0.1' WITH GRANT OPTION;
+FLUSH PRIVILEGES;\"",
+        unless  => "/usr/bin/mysql -e \"SHOW GRANTS FOR '${db_user}'@'127.0.0.1'\" | grep -q \"TO '${db_user}'\"",
+        user    => 'root',
+    }
+}

--- a/manifests/hive/server.pp
+++ b/manifests/hive/server.pp
@@ -1,0 +1,43 @@
+# == Class cdh4::hive::server
+# Configures hive-server2.  Requires that cdh4::hadoop is included so that
+# hadoop-client is available to create hive HDFS directories.
+#
+# See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.0/CDH4-Installation-Guide/cdh4ig_topic_18_5.html
+#
+class cdh4::hive::server
+{
+    # cdh4::hive::server requires hadoop client and configs are installed.
+    Class['cdh4::hadoop'] -> Class['cdh4::hive::server']
+    Class['cdh4::hive']   -> Class['cdh4::hive::server']
+
+    package { 'hive-server2':
+        ensure => 'installed',
+        alias  => 'hive-server',
+    }
+
+    # sudo -u hdfs hadoop fs -mkdir /user/hive
+    # sudo -u hdfs hadoop fs -chmod 0775 /user/hive
+    # sudo -u hdfs hadoop fs -chown hive:hadoop /user/hive
+    cdh4::hadoop::directory { '/user/hive':
+        owner   => 'hive',
+        group   => 'hadoop',
+        mode    => '0775',
+        require => Package['hive'],
+    }
+    # sudo -u hdfs hadoop fs -mkdir /user/hive/warehouse
+    # sudo -u hdfs hadoop fs -chmod 1777 /user/hive/warehouse
+    # sudo -u hdfs hadoop fs -chown hive:hadoop /user/hive/warehouse
+    cdh4::hadoop::directory { '/user/hive/warehouse':
+        owner   => 'hive',
+        group   => 'hadoop',
+        mode    => '1777',
+        require => Cdh4::Hadoop::Directory['/user/hive'],
+    }
+
+    service { 'hive-server2':
+        ensure     => 'running',
+        require    => Package['hive-server2'],
+        hasrestart => true,
+        hasstatus  => true,
+    }
+}

--- a/manifests/hue.pp
+++ b/manifests/hue.pp
@@ -1,0 +1,173 @@
+# == Class cdh4::hue
+#
+# Installs hue, sets up the hue.ini file
+# and ensures that hue server is running.
+# This requires that cdh4::hadoop is included.
+#
+# If cdh4::hive and/or cdh4::oozie are included
+# on this node, hue will be configured to interface
+# with hive and oozie.
+#
+# == Parameters
+# $http_host              - IP for webservice to bind.
+# $http_port              - Port for webservice to bind.
+# $secret_key             - Secret key used for session hashing.
+#
+# $oozie_url              - URL for Oozie API.  If cdh4::oozie is included,
+#                           this will be inferred.  Else this will be disabled.
+# $oozie_security_enabled - Default: false.
+#
+# $smtp_host              - SMTP host for email notifications.
+#                           Default: undef, SMTP will not be configured.
+# $smtp_port              - SMTP port.                             Default: 25
+# $smtp_from_email        - Sender email address of notifications. Default: undef
+# $smtp_username          - Username for SMTP authentication.      Default: undef
+# $smtp_password          - Password for SMTP authentication.      Default: undef
+#
+# $httpfs_enabled         - If true, Hue will be configured to interact with HDFS via
+#                           HttpFS rather than the default WebHDFS.  You must
+#                           manually configure HttpFS on your namenode.
+#
+# $ssl_certificate        - Path to SSL certificate.  Default: /etc/ssl/certs/ssl-cert-snakeoil.pem
+# $ssl_private_key        - Path to SSL private key.  Default: /etc/ssl/private/ssl-cert-snakeoil.key
+#                           If ssl_certificate and ssl_private_key are set to the defaults,
+#                           the snakeoil certificates will be generated automatically for you.
+#
+# === LDAP parameters:
+# See hue.ini comments for documentation.  By default these are undefined.
+#
+# $ldap_url
+# $ldap_cert
+# $ldap_nt_domain
+# $ldap_bind_dn
+# $ldap_base_dn
+# $ldap_bind_password
+# $ldap_username_pattern
+# $ldap_user_filter
+# $ldap_user_name_attr
+# $ldap_group_filter
+# $ldap_group_name_attr
+# $ldap_group_member_attr
+#
+class cdh4::hue(
+    $http_host                = $cdh4::hue::defaults::http_host,
+    $http_port                = $cdh4::hue::defaults::http_port,
+    $secret_key               = $cdh4::hue::defaults::secret_key,
+
+    $oozie_url                = $cdh4::hue::defaults::oozie_url,
+    $oozie_security_enabled   = $cdh4::hue::defaults::oozie_security_enabled,
+
+    $smtp_host                = $cdh4::hue::defaults::smtp_host,
+    $smtp_port                = $cdh4::hue::defaults::smtp_port,
+    $smtp_user                = $cdh4::hue::defaults::smtp_user,
+    $smtp_password            = $cdh4::hue::defaults::smtp_password,
+    $smtp_from_email          = $cdh4::hue::defaults::smtp_from_email,
+
+    $httpfs_enabled           = $cdh4::hue::defaults::httpfs_enabled,
+
+    $ssl_certificate          = $cdh4::hue::defaults::ssl_certificate,
+    $ssl_private_key          = $cdh4::hue::defaults::ssl_private_key,
+
+    $ldap_url                 = $cdh4::hue::defaults::ldap_url,
+    $ldap_cert                = $cdh4::hue::defaults::ldap_cert,
+    $ldap_nt_domain           = $cdh4::hue::defaults::ldap_nt_domain,
+    $ldap_bind_dn             = $cdh4::hue::defaults::ldap_bind_dn,
+    $ldap_base_dn             = $cdh4::hue::defaults::ldap_base_dn,
+    $ldap_bind_password       = $cdh4::hue::defaults::ldap_bind_password,
+    $ldap_username_pattern    = $cdh4::hue::defaults::ldap_username_pattern,
+    $ldap_user_filter         = $cdh4::hue::defaults::ldap_user_filter,
+    $ldap_user_name_attr      = $cdh4::hue::defaults::ldap_user_name_attr,
+    $ldap_group_filter        = $cdh4::hue::defaults::ldap_group_filter,
+    $ldap_group_name_attr     = $cdh4::hue::defaults::ldap_group_name_attr,
+    $ldap_group_member_attr   = $cdh4::hue::defaults::ldap_group_member_attr,
+
+    $hue_ini_template       = $cdh4::hue::defaults::hue_ini_template
+) inherits cdh4::hue::defaults
+{
+    Class['cdh4::hadoop'] -> Class['cdh4::hue']
+
+    package { ['hue', 'hue-server']:
+        ensure => 'installed'
+    }
+
+    # Managing the hue user here so we can add
+    # it to the hive group if hive-site.xml is
+    # not world readable.
+    user { 'hue':
+        gid        => 'hue',
+        comment    => 'Hue daemon',
+        home       => '/usr/share/hue',
+        shell      => '/bin/false',
+        managehome => false,
+        system     => true,
+        require    => [Package['hue'], Package['hue-server']],
+    }
+    # hive-site.xml might not be world readable.
+    if (defined(Class['cdh4::hive'])) {
+        # make sure cdh4::hive is applied before cdh4::hue.
+        Class['cdh4::hive']  -> Class['cdh4::hue']
+        # Add the hue user to the hive group.
+        User['hue'] { groups +> 'hive'}
+
+        # Growl.  The packaged hue init.d script
+        # has a bug where it doesn't --chuid to hue.
+        # this causes hue not to be able to read the
+        # hive-site.xml file here, even though it is
+        # in the hive group.  Install our own patched
+        # init.d instead.  This will be removed once
+        # Cloudera fixes the problem.
+        # See: https://issues.cloudera.org/browse/HUE-1398
+        file { '/etc/init.d/hue':
+            source  => 'puppet:///modules/cdh4/hue/hue.init.d.sh',
+            mode    => '0755',
+            owner   => 'root',
+            group   => 'root',
+            require => Package['hue'],
+            notify  => Service['hue'],
+        }
+    }
+
+    if ($ssl_certificate and $ssl_private_key) {
+        if (!defined(Package['python-openssl'])) {
+            package{ 'python-openssl':
+                ensure => 'installed',
+            }
+        }
+
+        # If the ssl settings are left at the defaults (snakeoil),
+        # then run make-ssl-cert to generate the default snakeoil cert.
+        if (($ssl_certificate == $cdh4::hue::defaults::ssl_certificate) and
+            ($ssl_private_key == $cdh4::hue::defaults::ssl_private_key)) {
+
+            if (!defined(Package['ssl-cert'])) {
+                package{ 'ssl-cert':
+                    ensure => 'installed',
+                }
+            }
+
+            exec { 'generate_hue_snakeoil_ssl_cert':
+                command => '/usr/sbin/make-ssl-cert generate-default-snakeoil',
+                creates => $ssl_certificate,
+                require => Package['ssl-cert'],
+            }
+
+            # generate the cert before hue is started.
+            Exec['generate_hue_snakeoil_ssl_cert'] -> Service['hue']
+        }
+    }
+
+    $namenode_hostname = $cdh4::hadoop::namenode_hostname
+    file { '/etc/hue/hue.ini':
+        content => template($hue_ini_template),
+        require => Package['hue-server'],
+    }
+
+    service { 'hue':
+        ensure     => 'running',
+        enable     => true,
+        hasrestart => true,
+        hasstatus  => true,
+        subscribe  => File['/etc/hue/hue.ini'],
+        require    => [Package['hue-server'], User['hue']],
+    }
+}

--- a/manifests/hue.pp
+++ b/manifests/hue.pp
@@ -221,7 +221,7 @@ class cdh4::hue(
         $sqoop = false
     }
 
-    $namenode_hostname = $cdh4::hadoop::namenode_hostname
+    $namenode_host = $::cdh4::hadoop::primary_namenode_host
     file { '/etc/hue/hue.ini':
         content => template($hue_ini_template),
         require => Package['hue-server'],

--- a/manifests/hue.pp
+++ b/manifests/hue.pp
@@ -156,6 +156,16 @@ class cdh4::hue(
         }
     }
 
+    if (defined(Package['sqoop'])) {
+        $sqoop = 'sqoop'
+    }
+    elsif (defined(Package['sqoop2'])) {
+        $sqoop = 'sqoop2'
+    }
+    else {
+        $sqoop = false
+    }
+
     $namenode_hostname = $cdh4::hadoop::namenode_hostname
     file { '/etc/hue/hue.ini':
         content => template($hue_ini_template),

--- a/manifests/hue/defaults.pp
+++ b/manifests/hue/defaults.pp
@@ -1,0 +1,49 @@
+# == Class cdh4::hue::defaults
+#
+class cdh4::hue::defaults {
+    $http_host                = '0.0.0.0'
+    $http_port                = 8888
+    $secret_key               = undef
+
+    # Set Hue Oozie defaults to those already
+    # set in the cdh4::oozie class.
+    if (defined(Class['cdh4::oozie'])) {
+        $oozie_url                = $cdh4::oozie::url
+        # Is this the proper default values?  I'm not sure.
+        $oozie_security_enabled   = $cdh4::hue::defaults::oozie_security_enabled
+    }
+    # Otherwise disable Oozie interface for Hue.
+    else {
+        $oozie_url                = undef
+        $oozie_security_enabled   = undef
+    }
+
+    $smtp_host                = 'localhost'
+    $smtp_port                = 25
+    $smtp_user                = undef
+    $smtp_password            = undef
+    $smtp_from_email          = undef
+
+    $ssl_certificate          = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+    $ssl_private_key          = '/etc/ssl/private/ssl-cert-snakeoil.key'
+
+    # if httpfs is enabled, the default httpfs port
+    # will be used, instead of the webhdfs port.
+    $httpfs_enabled           = false
+
+    $ldap_url                 = undef
+    $ldap_cert                = undef
+    $ldap_nt_domain           = undef
+    $ldap_bind_dn             = undef
+    $ldap_base_dn             = undef
+    $ldap_bind_password       = undef
+    $ldap_username_pattern    = undef
+    $ldap_user_filter         = undef
+    $ldap_user_name_attr      = undef
+    $ldap_group_filter        = undef
+    $ldap_group_name_attr     = undef
+    $ldap_group_member_attr   = undef
+
+    $hue_ini_template         = 'cdh4/hue/hue.ini.erb'
+
+}

--- a/manifests/hue/defaults.pp
+++ b/manifests/hue/defaults.pp
@@ -24,8 +24,8 @@ class cdh4::hue::defaults {
     $smtp_password            = undef
     $smtp_from_email          = undef
 
-    $ssl_certificate          = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-    $ssl_private_key          = '/etc/ssl/private/ssl-cert-snakeoil.key'
+    $ssl_private_key          = '/etc/ssl/private/hue.key'
+    $ssl_certificate          = '/etc/ssl/certs/hue.cert'
 
     # if httpfs is enabled, the default httpfs port
     # will be used, instead of the webhdfs port.

--- a/manifests/oozie.pp
+++ b/manifests/oozie.pp
@@ -1,0 +1,24 @@
+# == Class cdh4::oozie
+# Installs the oozie-client package
+# And sets OOZIE_URL in /etc/profile.d/oozie.sh.
+#
+class cdh4::oozie(
+    $oozie_host = 'localhost'
+)
+{
+    # oozie server url
+    $url = "http://$oozie_host:11000/oozie"
+
+    package { 'oozie-client':
+        ensure => 'installed',
+    }
+
+    # create a file in /etc/profile.d to export OOZIE_URL.
+    file { '/etc/profile.d/oozie.sh':
+        content => "# NOTE:  This file is managed by Puppet.
+
+export OOZIE_URL='${url}'
+",
+        mode    => '0444',
+    }
+}

--- a/manifests/oozie/database/mysql.pp
+++ b/manifests/oozie/database/mysql.pp
@@ -1,0 +1,52 @@
+# == Class cdh4::oozie::database::mysql
+# Configures and sets up a MySQL database for Oozie.
+#
+# Note that this class does not support running
+# the Oozie database on a different host than where your
+# oozie server will run.  Permissions will only be granted
+# for localhost MySQL users, so oozie server must run on this node.
+#
+# Also, root must be able to run /usr/bin/mysql with no password and have permissions
+# to create databases and users and grant permissions.
+#
+# You probably shouldn't be including this class directly.  Instead, include
+# cdh4::oozie::server with database => 'mysql'.
+#
+# See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.1/CDH4-Installation-Guide/cdh4ig_topic_17_6.html
+#
+class cdh4::oozie::database::mysql {
+    if (!defined(Package['libmysql-java'])) {
+        package { 'libmysql-java':
+            ensure => 'installed',
+        }
+    }
+
+    # symlink mysql.jar into /var/lib/oozie
+    file { '/var/lib/oozie/mysql.jar':
+        ensure  => 'link',
+        target  => '/usr/share/java/mysql.jar',
+        require => Package['libmysql-java'],
+    }
+
+    $db_name = $cdh4::oozie::server::jdbc_database
+    $db_user = $cdh4::oozie::server::jdbc_username
+    $db_pass = $cdh4::oozie::server::jdbc_password
+
+    # oozie is going to need an oozie database and user.
+    exec { 'oozie_mysql_create_database':
+        command => "/usr/bin/mysql -e \"
+CREATE DATABASE ${db_name};
+GRANT ALL PRIVILEGES ON ${db_name}.* TO '${db_user}'@'localhost' IDENTIFIED BY '${db_pass}';
+GRANT ALL PRIVILEGES ON ${db_name}.* TO '${db_user}'@'127.0.0.1' IDENTIFIED BY '${db_pass}';\"",
+        unless  => "/usr/bin/mysql -BNe 'SHOW DATABASES' | /bin/grep -q ${db_name}",
+        user    => 'root',
+    }
+
+    # run ooziedb.sh to create the oozie database schema
+    exec { 'oozie_mysql_create_schema':
+        command => '/usr/lib/oozie/bin/ooziedb.sh create -run',
+        require => [Exec['oozie_mysql_create_database'], File['/var/lib/oozie/mysql.jar']],
+        unless  => "/usr/bin/mysql -u${db_user} -p'${db_pass}' ${db_name} -BNe 'SHOW TABLES;' | /bin/grep -q OOZIE_SYS",
+        user    => 'oozie',
+    }
+}

--- a/manifests/oozie/defaults.pp
+++ b/manifests/oozie/defaults.pp
@@ -1,0 +1,28 @@
+# == Class cdh4::oozie::defaults
+#
+class cdh4::oozie::defaults {
+    $database                               = 'mysql'
+
+    $jdbc_driver                            = 'com.mysql.jdbc.Driver'
+    $jdbc_protocol                          = 'mysql'
+    $jdbc_database                          = 'oozie'
+    $jdbc_host                              = 'localhost'
+    $jdbc_port                              = 3306
+    $jdbc_username                          = 'oozie'
+    $jdbc_password                          = 'oozie'
+
+    $smtp_host                              = undef
+    $smtp_port                              = 25
+    $smtp_from_email                        = undef
+    $smtp_username                          = undef
+    $smtp_password                          = undef
+
+    $authorization_service_security_enabled = true
+
+    # Default puppet paths to template config files.
+    # This allows us to use custom template config files
+    # if we want to override more settings than this
+    # module yet supports.
+    $oozie_site_template                    = 'cdh4/oozie/oozie-site.xml.erb'
+    $oozie_env_template                     = 'cdh4/oozie/oozie-env.sh.erb'
+}

--- a/manifests/oozie/server.pp
+++ b/manifests/oozie/server.pp
@@ -1,0 +1,171 @@
+# == Class cdh4::oozie::server
+#
+# Installs and configureds oozie server.  If database is set,
+# The oozie database will also be created by the database class.
+#
+# See: http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.1/CDH4-Installation-Guide/cdh4ig_topic_17_6.html
+#
+# == Parameters
+# $database                      - Name of database class.
+#                                  Set to undef to disable configuartion of Oozie database.
+#                                  Default: mysql
+#
+# $jdbc_database                 - Oozie database name.                   Default: oozie
+# $jdbc_username                 - Oozie JDBC username.                   Default: oozie
+# $jdbc_password                 - Oozie JDBC password.                   Default: oozie
+# $jdbc_host                     - Oozie JDBC hostname.                   Default: localhost
+# $jdbc_port                     - Oozie JDBC port.                       Default: 3306
+# $jdbc_driver                   - Oozie JDBC driver class name.          Default: com.mysql.jdbc.Driver
+# $jdbc_protocol                 - Name of database protocol.             Default: mysql
+#
+# $smtp_host                     - SMTP host for email notifications.
+#                                  Default: undef, SMTP will not be configured.
+# $smtp_port                     - SMTP port.                             Default: 25
+# $smtp_from_email               - Sender email address of notifications. Default: undef
+# $smtp_username                 - Username for SMTP authentication.      Default: undef
+# $smtp_password                 - Password for SMTP authentication.      Default: undef
+#
+# $authorization_service_security_enabled -  If disabled any user can manage Oozie
+#                                            system and manage any job.  Default: true
+#
+class cdh4::oozie::server(
+    $database                               = $cdh4::oozie::defaults::database,
+
+    $jdbc_database                          = $cdh4::oozie::defaults::jdbc_database,
+    $jdbc_username                          = $cdh4::oozie::defaults::jdbc_username,
+    $jdbc_password                          = $cdh4::oozie::defaults::jdbc_password,
+    $jdbc_host                              = $cdh4::oozie::defaults::jdbc_host,
+    $jdbc_port                              = $cdh4::oozie::defaults::jdbc_port,
+    $jdbc_driver                            = $cdh4::oozie::defaults::jdbc_driver,
+    $jdbc_protocol                          = $cdh4::oozie::defaults::jdbc_protocol,
+
+    $smtp_host                              = $cdh4::oozie::defaults::smtp_host,
+    $smtp_port                              = $cdh4::oozie::defaults::smtp_port,
+    $smtp_from_email                        = $cdh4::oozie::defaults::smtp_from_email,
+    $smtp_username                          = $cdh4::oozie::defaults::smtp_username,
+    $smtp_password                          = $cdh4::oozie::defaults::smtp_password,
+
+    $authorization_service_security_enabled = $cdh4::oozie::defaults::authorization_service_security_enabled,
+
+    $oozie_site_template                    = $cdh4::oozie::defaults::oozie_site_template,
+    $oozie_env_template                     = $cdh4::oozie::defaults::oozie_env_template
+) inherits cdh4::oozie::defaults
+{
+    # cdh4::oozie::server requires hadoop client and configs are installed.
+    Class['cdh4::hadoop'] -> Class['cdh4::oozie::server']
+    # Also require cdh4::oozie client class.
+    Class['cdh4::oozie']  -> Class['cdh4::oozie::server']
+
+    package { 'oozie':
+        ensure => 'installed',
+    }
+
+    if (!defined(Package['libjs-extjs'])) {
+        package { 'libjs-extjs':
+            ensure => 'installed',
+        }
+    }
+    # Symlink extjs install path into /var/lib/oozie.
+    # This is required for the Oozie web interface to work.
+    file { '/var/lib/oozie/extjs':
+        ensure  => 'link',
+        target  => '/usr/share/javascript/extjs',
+        require => [Package['oozie'], Package['libjs-extjs']],
+    }
+
+    $catalina_base = $cdh4::hadoop::use_yarn ? {
+        true  => '/usr/lib/oozie/oozie-server',
+        false => '/usr/lib/oozie/oozie-server-0.20',
+    }
+    # Ensure that Catalina working directories exist.
+    # Without these, oozie will log the error:
+    # "The specified scratchDir is unusable: /usr/lib/oozie/oozie-server/work/Catalina/localhost/_"
+    file { ["${catalina_base}/work",
+            "${catalina_base}/work/Catalina",
+            "${catalina_base}/work/Catalina/localhost"]:
+        ensure  => 'directory',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        require => Package['oozie'],
+    }
+    file { ["${catalina_base}/work/Catalina/localhost/_",
+            "${catalina_base}/work/Catalina/localhost/oozie"]:
+        ensure  => 'directory',
+        owner   => 'oozie',
+        group   => 'oozie',
+        mode    => '0755',
+        require => File["${catalina_base}/work/Catalina/localhost"],
+    }
+
+    # Extract and install Oozie ShareLib into HDFS
+    # at /user/oozie/share
+
+    # sudo -u hdfs hadoop fs -mkdir /user/oozie
+    # sudo -u hdfs hadoop fs -chmod 0775 /user/oozie
+    # sudo -u hdfs hadoop fs -chown hive:hadoop /user/oozie
+    cdh4::hadoop::directory { '/user/oozie':
+        owner   => 'oozie',
+        group   => 'hadoop',
+        mode    => '0755',
+        require => Package['oozie'],
+    }
+
+    # Put oozie sharelib into HDFS:
+    $oozie_sharelib_archive = $cdh4::hadoop::use_yarn ? {
+        true  => '/usr/lib/oozie/oozie-sharelib-yarn.tar.gz',
+        false => '/usr/lib/oozie/oozie-sharelib.tar.gz',
+    }
+    $oozie_sharelib_tmpdir = inline_template('/tmp/oozie_sharelib_install.<%= rand() %>')
+    exec { 'oozie_sharelib_install':
+        command => "\
+/bin/mkdir -p ${oozie_sharelib_tmpdir}                                   && \
+/bin/tar -C ${oozie_sharelib_tmpdir} -xzf ${oozie_sharelib_archive}      && \
+/usr/bin/hadoop fs -put ${oozie_sharelib_tmpdir}/share /user/oozie/share && \
+/bin/rm -rf ${oozie_sharelib_tmpdir}",
+        # don't run this command if /user/oozie/share already exists in HDFS.
+        unless  => '/usr/bin/hadoop fs -ls /user/oozie | grep -q /user/oozie/share',
+        user    => 'oozie',
+        require => Cdh4::Hadoop::Directory['/user/oozie'],
+    }
+
+    file { '/etc/oozie/conf/oozie-site.xml':
+        content => template($oozie_site_template),
+        mode    => '0440',  # has database pw in it, shouldn't be world readable.
+        owner   => 'root',
+        group   => 'oozie',
+        require => Package['oozie'],
+    }
+    file { '/etc/oozie/conf/oozie-env.sh':
+        content => template($oozie_env_template),
+        mode    => '0444',
+        owner   => 'root',
+        group   => 'oozie',
+        require => Package['oozie'],
+    }
+
+    # Set up the database by including $database_class
+    $database_class = "cdh4::oozie::database::${database}"
+    if ($database) {
+        class { $database_class: }
+        # Make sure the $database_class is included and set up
+        # before we start the oozie server service
+        Class[$database_class] -> Service['oozie']
+    }
+
+    service { 'oozie':
+        ensure     => 'running',
+        hasrestart => true,
+        hasstatus  => true,
+        subscribe  => [
+            File['/etc/oozie/conf/oozie-site.xml'],
+            File['/etc/oozie/conf/oozie-env.sh']
+        ],
+        require    => [
+            File['/var/lib/oozie/extjs'],
+            # Package['libcnative-1'],
+            File["${catalina_base}/work/Catalina/localhost/oozie"],
+            File["${catalina_base}/work/Catalina/localhost/_"]
+        ],
+    }
+}

--- a/manifests/pig.pp
+++ b/manifests/pig.pp
@@ -3,12 +3,12 @@
 # Installs and configures Apache Pig.
 #
 class cdh4::pig {
-  package { 'pig':
-    ensure => 'installed',
-  }
+    package { 'pig':
+        ensure => 'installed',
+    }
 
-  file { '/etc/pig/conf/pig.properties':
-    content => template('cdh4/pig/pig.properties.erb'),
-    require => Package['pig'],
-  }
+    file { '/etc/pig/conf/pig.properties':
+        content => template('cdh4/pig/pig.properties.erb'),
+        require => Package['pig'],
+    }
 }

--- a/manifests/sqoop.pp
+++ b/manifests/sqoop.pp
@@ -1,16 +1,16 @@
 # == Class cdh4::sqoop
 # Installs Sqoop
 class cdh4::sqoop {
-  package { ['sqoop', 'libmysql-java']:
-    ensure => 'installed',
-  }
+    package { ['sqoop', 'libmysql-java']:
+        ensure => 'installed',
+    }
 
-  # symlink the mysql-connector-java.jar that is installed by
-  # libmysql-java into /usr/lib/sqoop/lib
+    # symlink the mysql-connector-java.jar that is installed by
+    # libmysql-java into /usr/lib/sqoop/lib
 
-  file { '/usr/lib/sqoop/lib/mysql-connector-java.jar':
-    ensure  => 'link',
-    target  => '/usr/share/java/mysql-connector-java.jar',
-    require => [Package['sqoop'], Package['libmysql-java']],
-  }
+    file { '/usr/lib/sqoop/lib/mysql-connector-java.jar':
+        ensure  => 'link',
+        target  => '/usr/share/java/mysql-connector-java.jar',
+        require => [Package['sqoop'], Package['libmysql-java']],
+    }
 }

--- a/manifests/sqoop.pp
+++ b/manifests/sqoop.pp
@@ -1,13 +1,18 @@
 # == Class cdh4::sqoop
 # Installs Sqoop
 class cdh4::sqoop {
-    package { ['sqoop', 'libmysql-java']:
+    package { 'sqoop':
         ensure => 'installed',
     }
 
+    if (!defined(Package['libmysql-java'])) {
+        package { 'libmysql-java':
+            ensure => 'installed',
+        }
+    }
     # symlink the mysql-connector-java.jar that is installed by
     # libmysql-java into /usr/lib/sqoop/lib
-
+    # TODO: Can I create this symlink as mysql.jar?
     file { '/usr/lib/sqoop/lib/mysql-connector-java.jar':
         ensure  => 'link',
         target  => '/usr/share/java/mysql-connector-java.jar',

--- a/templates/hadoop/core-site.xml.erb
+++ b/templates/hadoop/core-site.xml.erb
@@ -8,7 +8,7 @@
 <configuration>
 
   <property>
-    <name>fs.defaultFS</name>
+    <name><%= @use_yarn ? 'fs.defaultFS' : 'fs.default.name' %></name>
     <value>hdfs://<%= namenode_hostname %>/</value>
   </property>
   

--- a/templates/hadoop/core-site.xml.erb
+++ b/templates/hadoop/core-site.xml.erb
@@ -9,9 +9,9 @@
 
   <property>
     <name><%= @use_yarn ? 'fs.defaultFS' : 'fs.default.name' %></name>
-    <value>hdfs://<%= namenode_hostname %>/</value>
+    <value>hdfs://<%= @ha_enabled ? @nameservice_id : @primary_namenode_host %>/</value>
   </property>
-  
+
 <% if @io_file_buffer_size -%>
   <property>
     <name>io.file.buffer.size</name>

--- a/templates/hadoop/hadoop-metrics2.properties.erb
+++ b/templates/hadoop/hadoop-metrics2.properties.erb
@@ -1,0 +1,43 @@
+# NOTE: This file is managed by Puppet.
+
+# syntax: [prefix].[source|sink].[instance].[options]
+# See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
+
+# default sampling period, in seconds
+*.period=10
+
+<% if @ganglia_hosts
+ganglia_hosts_string = ganglia_hosts.sort.join(',')
+-%>
+#
+# Below are for sending metrics to Ganglia
+#
+
+# for Ganglia 3.1 support
+*.sink.ganglia.class=org.apache.hadoop.metrics2.sink.ganglia.GangliaSink31
+
+*.sink.ganglia.period=10
+
+# default for supportsparse is false
+# *.sink.ganglia.supportsparse=true
+
+*.sink.ganglia.slope=jvm.metrics.gcCount=zero,jvm.metrics.memHeapUsedM=both
+*.sink.ganglia.dmax=jvm.metrics.threadsBlocked=70,jvm.metrics.memHeapUsedM=40
+
+namenode.sink.ganglia.servers=<%= ganglia_hosts_string %>
+datanode.sink.ganglia.servers=<%= ganglia_hosts_string %>
+
+<% if use_yarn -%>
+resourcemanager.sink.ganglia.servers=<%= ganglia_hosts_string %>
+nodemanager.sink.ganglia.servers=<%= ganglia_hosts_string %>
+<% else -%>
+jobtracker.sink.ganglia.servers=<%= ganglia_hosts_string %>
+tasktracker.sink.ganglia.servers=<%= ganglia_hosts_string %>
+<% end -%>
+
+maptask.sink.ganglia.servers=<%= ganglia_hosts_string %>
+reducetask.sink.ganglia.servers=<%= ganglia_hosts_string %>
+
+secondarynamenode.sink.ganglia.servers=<%= ganglia_hosts_string %>
+
+<% end -%>

--- a/templates/hadoop/hdfs-site.xml.erb
+++ b/templates/hadoop/hdfs-site.xml.erb
@@ -1,3 +1,13 @@
+<%
+# Convert a namenode hostname to a NameNode ID.
+# We can't use '.' characters because NameNode IDs.
+# will be used in the names of some Java properties, 
+# which are '.' delimited.
+def namenode_host_to_id(host)
+  host.tr('.', '-')
+end
+
+-%>
 <?xml version="1.0"?>
 <!-- NOTE:  This file is managed by Puppet. -->
 
@@ -11,6 +21,53 @@
    <value>hadoop</value>
   </property>
 
+<% if @ha_enabled -%>
+  <property>
+    <name>dfs.nameservices</name>
+    <value><%= @nameservice_id %></value>
+  </property>
+
+  <property>
+    <name>dfs.ha.namenodes.<%= @nameservice_id %></name>
+    <value><%= @namenode_hosts.sort.collect { |host| namenode_host_to_id(host) }.join(',') %></value>
+  </property>
+
+<% @namenode_hosts.sort.each do |host| -%>
+  <property>
+    <name>dfs.namenode.rpc-address.<%= @nameservice_id %>.<%= namenode_host_to_id(host) %></name>
+    <value><%= host %>:8020</value>
+  </property>
+<% end # @namenode_hosts.each -%>
+
+<% @namenode_hosts.sort.each do |host| -%>
+  <property>
+    <name>dfs.namenode.http-address.<%= @nameservice_id %>.<%= namenode_host_to_id(host) %></name>
+    <value><%= host %>:50070</value>
+  </property>
+<% end # @namenode_hosts.each -%>
+
+  <property>
+    <name>dfs.namenode.shared.edits.dir</name>
+    <value>qjournal://<%= @journalnode_hosts.sort.join(':8485;') %>:8485/<%= @nameservice_id %></value>
+  </property>
+
+  <property>
+    <name>dfs.journalnode.edits.dir</name>
+    <value><%= @dfs_journalnode_edits_dir %></value>
+  </property>
+
+  <property>
+    <name>dfs.client.failover.proxy.provider.<%= @nameservice_id %></name>
+    <value>org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider</value>
+  </property>
+
+  <!-- Quorum-based JournalNode HA does not require fencing. -->
+  <property>
+    <name>dfs.ha.fencing.methods</name>
+    <value>shell(/bin/true)</value>
+  </property>
+
+<% end # if @ha_enabled -%>
   <property>
    <name>dfs.namenode.name.dir</name>
    <value>file://<%= (dfs_name_dir.class == Array) ? dfs_name_dir.join(',file://') : dfs_name_dir %></value>
@@ -19,7 +76,7 @@
 <% if @datanode_mounts -%>
   <property>
    <name>dfs.datanode.data.dir</name>
-   <value>file://<%= datanode_mounts.collect { |mount| mount + "/" + dfs_data_path }.join(',file://') %></value>
+   <value>file://<%= datanode_mounts.sort.collect { |mount| mount + "/" + dfs_data_path }.join(',file://') %></value>
   </property>
 <% end -%>
 
@@ -41,4 +98,5 @@
       This is useful for decommissioning nodes.
     </description>
   </property>
+
 </configuration>

--- a/templates/hadoop/mapred-site.xml.erb
+++ b/templates/hadoop/mapred-site.xml.erb
@@ -14,7 +14,7 @@
 
   <property>
    <name>mapreduce.jobhistory.address</name>
-   <value><%= namenode_hostname %>:10020</value>
+   <value><%= @primary_namenode_host %>:10020</value>
   </property>
 
   <property>
@@ -41,9 +41,10 @@
 <% else -%>
   <property>
     <name>mapred.job.tracker</name>
-    <value><%= namenode_hostname %>:8021</value>
+    <value><%= @primary_namenode_host %>:8021</value>
   </property>
 <% if @mapreduce_system_dir -%>
+
   <property>
     <name>mapred.system.dir</name>
     <value><%= @mapreduce_system_dir %></value>

--- a/templates/hadoop/mapred-site.xml.erb
+++ b/templates/hadoop/mapred-site.xml.erb
@@ -43,6 +43,12 @@
     <name>mapred.job.tracker</name>
     <value><%= namenode_hostname %>:8021</value>
   </property>
+<% if @mapreduce_system_dir -%>
+  <property>
+    <name>mapred.system.dir</name>
+    <value><%= @mapreduce_system_dir %></value>
+  </property>
+<% end -%>
 <% end -%>
 
 <% if @mapreduce_map_tasks_maximum -%>

--- a/templates/hadoop/yarn-site.xml.erb
+++ b/templates/hadoop/yarn-site.xml.erb
@@ -9,19 +9,19 @@
 
   <property>
     <name>yarn.resourcemanager.scheduler.address</name>
-    <value><%= namenode_hostname %>:8030</value>
+    <value><%= @primary_namenode_host %>:8030</value>
   </property>
   <property>
     <name>yarn.resourcemanager.resource-tracker.address</name>
-    <value><%= namenode_hostname %>:8031</value>
+    <value><%= @primary_namenode_host %>:8031</value>
   </property>
   <property>
     <name>yarn.resourcemanager.address</name>
-    <value><%= namenode_hostname %>:8032</value>
+    <value><%= @primary_namenode_host %>:8032</value>
   </property>
   <property>
     <name>yarn.resourcemanager.admin.address</name>
-    <value><%= namenode_hostname %>:8033</value>
+    <value><%= @primary_namenode_host %>:8033</value>
   </property>
   <property>
     <name>yarn.resourcemanager.webapp.address</name>

--- a/templates/hbase/hbase-site.xml.erb
+++ b/templates/hbase/hbase-site.xml.erb
@@ -30,4 +30,10 @@
     <name>hbase.rootdir</name>
     <value>hdfs://<%= @master_domain %>:8020<%= @root_dir %></value>
 </property>
+<% if @zookeeper_master -%>
+<property>
+    <name>hbase.zookeeper.quorum</name>
+    <value><%= @zookeeper_master %></value>
+</property>
+<% end -%>
 </configuration>

--- a/templates/hbase/hbase-site.xml.erb
+++ b/templates/hbase/hbase-site.xml.erb
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+<property>
+    <name>hbase.cluster.distributed</name>
+    <value>true</value>
+</property>
+<property>
+    <name>hbase.rootdir</name>
+    <value>hdfs://<%= @master_domain %>:8020<%= @root_dir %></value>
+</property>
+</configuration>

--- a/templates/hbase/hbase-site.xml.erb
+++ b/templates/hbase/hbase-site.xml.erb
@@ -28,12 +28,12 @@
 </property>
 <property>
     <name>hbase.rootdir</name>
-    <value>hdfs://<%= @master_domain %>:8020<%= @root_dir %></value>
+    <value>hdfs://<%= @namenode_host %>:8020<%= @rootdir %></value>
 </property>
-<% if @zookeeper_master -%>
+<% if @zookeeper_hosts -%>
 <property>
     <name>hbase.zookeeper.quorum</name>
-    <value><%= @zookeeper_master %></value>
+    <value><%= @zookeeper_hosts.sort.join(',') %></value>
 </property>
 <% end -%>
 </configuration>

--- a/templates/hive/hive-exec-log4j.properties.erb
+++ b/templates/hive/hive-exec-log4j.properties.erb
@@ -1,0 +1,39 @@
+hive.log.threshold=INFO
+hive.root.logger=INFO,RFA
+hive.log.dir=/var/log/hive
+hive.log.file=${hive.query.id}.log
+
+# Define the root logger to the system property "hive.root.logger".
+log4j.rootLogger=${hive.root.logger}, EventCounter
+
+# Logging Threshold
+log4j.threshhold=${hive.log.threshold}
+
+#
+# Rolling File Appender - cap space usage at 512MB
+#
+hive.log.maxfilesize=256MB
+hive.log.maxbackupindex=2
+log4j.appender.RFA=org.apache.log4j.RollingFileAppender
+log4j.appender.RFA.File=${hive.log.dir}/${hive.log.file}
+log4j.appender.RFA.MaxFileSize=${hive.log.maxfilesize}
+log4j.appender.RFA.MaxBackupIndex=${hive.log.maxbackupindex}
+log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+# Pattern format: Date LogLevel LoggerName LogMessage
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+
+#
+# Event Counter Appender
+# Sends counts of logging messages at different severity levels to Hadoop Metrics.
+#
+log4j.appender.EventCounter=org.apache.hadoop.metrics.jvm.EventCounter
+
+log4j.category.DataNucleus=ERROR,RFA
+log4j.category.Datastore=ERROR,RFA
+log4j.category.Datastore.Schema=ERROR,RFA
+log4j.category.JPOX.Datastore=ERROR,RFA
+log4j.category.JPOX.Plugin=ERROR,RFA
+log4j.category.JPOX.MetaData=ERROR,RFA
+log4j.category.JPOX.Query=ERROR,RFA
+log4j.category.JPOX.General=ERROR,RFA
+log4j.category.JPOX.Enhancer=ERROR,RFA

--- a/templates/hive/hive-site.xml.erb
+++ b/templates/hive/hive-site.xml.erb
@@ -1,0 +1,259 @@
+<?xml version="1.0"?>
+<!-- NOTE:  This file is managed by Puppet. -->
+
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+
+  <!-- Hive Configuration can either be stored in this file or in the hadoop configuration files  -->
+  <!-- that are implied by Hadoop setup variables.                                                -->
+  <!-- Aside from Hadoop setup variables - this file is provided as a convenience so that Hive    -->
+  <!-- users do not have to edit hadoop configuration files (that may be managed as a centralized -->
+  <!-- resource).                                                                                 -->
+
+  <!-- Hive metastore configuration -->
+  <property>
+    <name>hive.metastore.uris</name>
+    <value>thrift://<%= @metastore_host %>:9083</value>
+    <description>Fully-qualified domain name and port of the metastore host</description>
+  </property>
+<%
+
+# if this node is the metastore_host, then render out
+# metastore backend database connection credentials
+# TODO: Possibly use hive-default.xml + hive-site.xml to only
+# render hive-site.xml with these credentials on metastore_host.
+if (@metastore_host == @fqdn)
+-%>
+
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <value><%= "jdbc:#{@jdbc_protocol}://#{@jdbc_host}:#{@jdbc_port}/#{@jdbc_database}" %></value>
+    <description>JDBC connect string for a JDBC metastore</description>
+  </property>
+
+  <property>
+    <name>javax.jdo.option.ConnectionDriverName</name>
+    <value><%= @jdbc_driver %></value>
+    <description>Driver class name for a JDBC metastore</description>
+  </property>
+
+  <% if @jdbc_username -%>
+  <property>
+    <name>javax.jdo.option.ConnectionUserName</name>
+    <value><%= @jdbc_username %></value>
+  </property>
+  <% end -%>
+
+  <% if @jdbc_password and @jdbc_password.empty? == false -%>
+  <property>
+    <name>javax.jdo.option.ConnectionPassword</name>
+    <value><%= @jdbc_password %></value>
+  </property>
+  <% end -%>
+
+  <property>
+    <name>datanucleus.autoCreateSchema</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>datanucleus.fixedDatastore</name>
+    <value>true</value>
+  </property>
+
+<% end -%>
+<% if @zookeeper_hosts -%>
+  <!-- Hive can use Zookeeper for table lock management -->
+  <property>
+    <name>hive.support.concurrency</name>
+    <description>Enable Hive's Table Lock Manager Service</description>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>hive.zookeeper.quorum</name>
+    <description>Zookeeper quorum used by Hive's Table Lock Manager</description>
+    <value><%= @zookeeper_hosts.sort.join(',') %></value>
+  </property>
+<% end -%>
+
+
+  <!-- Hive Execution Parameters -->
+  <property>
+    <name>hive.cli.print.current.db</name>
+    <description>Whether to include the current database in the hive prompt.</description>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>hive.cli.print.header</name>
+    <description>Whether to print the names of the columns in query output.</description>
+    <value>true</value>
+  </property>
+
+
+  <property>
+    <name>hive.mapred.mode</name>
+    <description>
+      The mode in which the hive operations are being performed. 
+       In strict mode, some risky queries are not allowed to run. They include:
+       Cartesian Product.
+       No partition being picked up for a query.
+       Comparing bigints and strings.
+       Comparing bigints and doubles.
+       Orderby without limit.
+    </description>
+    <value>strict</value>
+  </property>
+
+  <property>
+    <name>hive.start.cleanup.scratchdir</name>
+    <description>To cleanup the hive scratchdir while starting the hive server.</description>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>hive.error.on.empty.partition</name>
+    <description>Whether to throw an exception if dynamic partition insert generates empty results.</description>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>hive.insert.into.external.tables</name>
+    <description>https://issues.apache.org/jira/browse/HIVE-2837</description>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>hive.exec.parallel</name>
+    <description>Whether to execute jobs in parallel</description>
+    <value><%= @exec_parallel_thread_number.to_i > 0 ? 'true' : 'false' %></value>
+  </property>
+
+  <property>
+    <name>hive.exec.parallel.thread.number</name>
+    <description>How many jobs at most can be executed in parallel</description>
+    <value><% @exec_parallel_thread_number %></value>
+  </property>
+
+<% if @optimize_skewjoin -%>
+  <property>
+    <name>hive.optimize.skewjoin</name>
+    <value><%= @optimize_skewjoin %></value>
+    <description>
+      Whether to enable skew join optimization.
+      The algorithm is as follows: At runtime, detect the keys with a large skew. Instead of
+      processing those keys, store them temporarily in a hdfs directory. In a follow-up map-reduce
+      job, process those skewed keys. The same key need not be skewed for all the tables, and so,
+      the follow-up map-reduce job (for the skewed keys) would be much faster, since it would be a 
+      map-join.
+    </description>
+  </property>
+
+  <property>
+    <name>hive.skewjoin.key</name>
+    <value><%= @skewjoin_key %></value>
+    <description>
+      Determine if we get a skew key in join. If we see more
+      than the specified number of rows with the same key in join operator,
+      we think the key as a skew join key.
+    </description>
+  </property>
+
+  <property>
+    <name>hive.skewjoin.mapjoin.map.tasks</name>
+    <value><%= @skewjoin_mapjoin_map_tasks %></value>
+    <description>
+      Determine the number of map task used in the follow up map join job
+      for a skew join. It should be used together with hive.skewjoin.mapjoin.min.split
+      to perform a fine grained control.
+    </description>
+  </property>
+
+  <property>
+    <name>hive.skewjoin.mapjoin.min.split</name>
+    <value><%= @skewjoin_mapjoin_min_split %></value>
+    <description>
+      Determine the number of map task at most used in the follow up map join job
+      for a skew join by specifying the minimum split size. It should be used together with
+      hive.skewjoin.mapjoin.map.tasks to perform a fine grained control.
+    </description>
+  </property>
+<% end -%>
+
+<% if @stats_enabled -%>
+  <!-- Hive stats configuration -->
+  <property>
+    <name>hive.stats.dbclass</name>
+    <value><%= @stats_dbclass %></value>
+    <description>The default database that stores temporary hive statistics.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.jdbcdriver</name>
+    <value><%= @stats_jdbcdriver %></value>
+    <description>The JDBC driver for the database that stores temporary hive statistics.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.dbconnectionstring</name>
+    <value><%= @stats_dbconnectionstring %></value>
+    <description>The default connection string for the database that stores temporary hive statistics.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.autogather</name>
+    <value>true</value>
+    <description>A flag to gather statistics automatically during the INSERT OVERWRITE command.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.default.publisher</name>
+    <value></value>
+    <description>The Java class (implementing the StatsPublisher interface) that is used by default if hive.stats.dbclass is not JDBC or HBase.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.default.aggregator</name>
+    <value></value>
+    <description>The Java class (implementing the StatsAggregator interface) that is used by default if hive.stats.dbclass is not JDBC or HBase.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.jdbc.timeout</name>
+    <value>30</value>
+    <description>Timeout value (number of seconds) used by JDBC connection and statements.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.retries.max</name>
+    <value>0</value>
+    <description>Maximum number of retries when stats publisher/aggregator got an exception updating intermediate database. Default is no tries on failures.</description>
+  </property>
+
+  <property>
+    <name>hive.stats.retries.wait</name>
+    <value>3000</value>
+    <description>The base waiting window (in milliseconds) before the next retry. The actual wait time is calculated by baseWindow * failues + baseWindow * (failure + 1) * (random number between [0.0,1.0]).</description>
+  </property>
+
+  <property>
+    <name>hive.stats.reliable</name>
+    <value>false</value>
+    <description>Whether queries will fail because stats cannot be collected completely accurately.
+      If this is set to true, reading/writing from/into a partition may fail becuase the stats
+      could not be computed accurately.
+    </description>
+  </property>
+
+  <property>
+    <name>hive.stats.collect.tablekeys</name>
+    <value>true</value>
+    <description>Whether join and group by keys on tables are derived and maintained in the QueryPlan.
+      This is useful to identify how tables are accessed and to determine if they should be bucketed.
+    </description>
+  </property>
+
+<% end -%>
+</configuration>

--- a/templates/hue/hue.ini.erb
+++ b/templates/hue/hue.ini.erb
@@ -1,0 +1,528 @@
+# Note: This file is managed by Puppet.
+
+# Hue configuration file
+# ===================================
+#
+# For complete documentation about the contents of this file, run
+#   $ <hue_root>/build/env/bin/hue config_help
+#
+# All .ini files under the current directory are treated equally.  Their
+# contents are merged to form the Hue configuration, which can
+# can be viewed on the Hue at
+#   http://<hue_host>:<port>/dump_config
+
+
+###########################################################################
+# General configuration for core Desktop features (authentication, etc)
+###########################################################################
+
+[desktop]
+
+  # Set this to a random string, the longer the better.
+  # This is used for secure hashing in the session store.
+  secret_key=<%= @secret_key ? secret_key : "" %>
+
+  # Webserver listens on this address and port
+  http_host=<%= @http_host %>
+  http_port=<%= @http_port %>
+
+  # Time zone name
+  time_zone=<%= @timezone %>
+
+  # Turn off debug
+  django_debug_mode=0
+
+  # Turn off backtrace for server error
+  http_500_debug_mode=0
+
+  # Server email for internal error messages
+  ## django_server_email='hue@localhost.localdomain'
+
+  # Email backend
+  ## django_email_backend=django.core.mail.backends.smtp.EmailBackend
+
+  # Set to true to use CherryPy as the webserver, set to false
+  # to use Spawning as the webserver. Defaults to Spawning if
+  # key is not specified.
+  ## use_cherrypy_server = false
+
+  # Webserver runs as this user
+  ## server_user=hue
+  ## server_group=hue
+
+  # If set to false, runcpserver will not actually start the web server.
+  # Used if Apache is being used as a WSGI container.
+  ## enable_server=yes
+
+  # Number of threads used by the CherryPy web server
+  ## cherrypy_server_threads=10
+
+  # Filename of SSL Certificate
+  <%= @ssl_certificate   ? "ssl_certificate=\"#{@ssl_certificate}\"" : "## base_dn=" %>
+
+  # Filename of SSL RSA Private Key
+  ## ssl_private_key=
+  <%= @ssl_private_key   ? "ssl_private_key=\"#{@ssl_private_key}\"" : "## base_dn=" %>
+
+
+  # Default encoding for site data
+  ## default_site_encoding=utf-8
+
+  # Administrators
+  # ----------------
+  [[django_admins]]
+    ## [[[admin1]]]
+    ## name=john
+    ## email=john@doe.com
+
+  # UI customizations
+  # -------------------
+  [[custom]]
+
+  # Top banner HTML code
+  ## banner_top_html=
+
+  # Configuration options for user authentication into the web application
+  # ------------------------------------------------------------------------
+  [[auth]]
+
+    # Authentication backend. Common settings are:
+    # - django.contrib.auth.backends.ModelBackend (entirely Django backend)
+    # - desktop.auth.backend.AllowAllBackend (allows everyone)
+    # - desktop.auth.backend.AllowFirstUserDjangoBackend
+    #     (Default. Relies on Django and user manager, after the first login)
+    # - desktop.auth.backend.LdapBackend
+    # - desktop.auth.backend.PamBackend
+    # - desktop.auth.backend.SpnegoDjangoBackend
+    # - desktop.auth.backend.RemoteUserDjangoBackend
+    ## backend=desktop.auth.backend.AllowFirstUserDjangoBackend
+    <%= @ldap_url ? "backend=desktop.auth.backend.LdapBackend" : "## backend=desktop.auth.backend.AllowFirstUserDjangoBackend" %>
+
+    ## pam_service=login
+
+    # When using the desktop.auth.backend.RemoteUserDjangoBackend, this sets
+    # the normalized name of the header that contains the remote user.
+    # The HTTP header in the request is converted to a key by converting
+    # all characters to uppercase, replacing any hyphens with underscores
+    # and adding an HTTP_ prefix to the name. So, for example, if the header
+    # is called Remote-User that would be configured as HTTP_REMOTE_USER
+    #
+    # Defaults to HTTP_REMOTE_USER
+    ## remote_user_header=HTTP_REMOTE_USER
+
+  # Configuration options for connecting to LDAP and Active Directory
+  # -------------------------------------------------------------------
+  [[ldap]]
+
+  # The search base for finding users and groups
+  <%= @ldap_base_dn          ? "base_dn=\"#{ldap_base_dn}\""                        : "## base_dn=\"DC=mycompany,DC=com\"" %>
+
+  # The NT domain to connect to (only for use with Active Directory)
+  <%= @ldap_nt_domain        ? "nt_domain=#{ldap_nt_domain}"                        : "## nt_domain=mycompany.com" %>
+
+  # URL of the LDAP server
+  <%= @ldap_url              ? "ldap_url=\"#{ldap_url}\""                           : "## ldap_url=ldap://auth.mycompany.com" %>
+
+  # Path to certificate for authentication over TLS
+  <%= @ldap_cert             ? "ldap_cert=#{ldap_cert}"                             : "## ldap_cert=" %>
+
+  # Distinguished name of the user to bind as -- not necessary if the LDAP server
+  # supports anonymous searches
+  <%= @ldap_bind_dn          ? "bind_dn=\"#{ldap_bind_dn}\""                        : "## bind_dn=\"CN=ServiceAccount,DC=mycompany,DC=com\"" %>
+
+  # Password of the bind user -- not necessary if the LDAP server supports
+  # anonymous searches
+  <%= @ldap_bind_password    ? "bind_password=#{ldap_bind_password}"                : "## bind_password=" %>
+
+  # Pattern for searching for usernames -- Use <username> for the parameter
+  # For use when using LdapBackend for Hue authentication
+  <%= @ldap_username_pattern ? "ldap_username_pattern=\"#{ldap_username_pattern}\"" : "## ldap_username_pattern=\"uid=<username>,ou=People,dc=mycompany,dc=com\"" %>
+
+  # Create users in Hue when they try to login with their LDAP credentials
+  # For use when using LdapBackend for Hue authentication
+  ## create_users_on_login = true
+
+      [[[users]]]
+
+      # Base filter for searching for users
+      <%= @ldap_user_filter       ? "user_filter=\"#{ldap_user_filter}\""             : "## user_filter=\"objectclass=*\"" %>
+
+      # The username attribute in the LDAP schema
+      <%= @ldap_user_name_attr    ? "user_name_attr=\"#{ldap_user_name_attr}\""       : "## user_name_attr=sAMAccountName" %>
+
+      [[[groups]]]
+
+      # Base filter for searching for groups
+      <%= @ldap_group_filter      ? "group_filter=\"#{ldap_group_filter}\""           : "## group_filter=\"objectclass=*\"" %>
+
+      # The group name attribute in the LDAP schema
+      <%= @ldap_group_name_attr   ? "group_name_attr=\"#{ldap_group_name_attr}\""     : "## group_name_attr=cn" %>
+
+      # The attribute of the group object which identifies the members of the group
+      <%= @ldap_group_member_attr ? "group_member_attr=\"#{ldap_group_member_attr}\"" : "## group_member_attr=members" %>
+
+  # Configuration options for specifying the Desktop Database.  For more info,
+  # see http://docs.djangoproject.com/en/1.1/ref/settings/#database-engine
+  # ------------------------------------------------------------------------
+  [[database]]
+    # Database engine is typically one of:
+    # postgresql_psycopg2, mysql, or sqlite3
+    #
+    # Note that for sqlite3, 'name', below is a filename;
+    # for other backends, it is the database name.
+    ## engine=sqlite3
+    ## host=
+    ## port=
+    ## user=
+    ## password=
+    ## name=
+
+
+  # Configuration options for connecting to an external SMTP server
+  # ------------------------------------------------------------------------
+  [[smtp]]
+
+    # The SMTP server information for email notification delivery
+    host=<%= @smtp_host %>
+    port=<%= @smtp_port %>
+    user=<%= @smtp_user %>
+    password=<%= @smtp_password %>
+
+    # Whether to use a TLS (secure) connection when talking to the SMTP server
+    tls=<%= (@smtp_user and !@smtp_user.empty?) ? 'yes' : 'no' %>
+
+    # Default email address to use for various automated notification from Hue
+    <%= @smtp_from_email ? "default_from_email=#{smtp_from_email}" : "## default_from_email=hue@localhost" %>
+
+
+  # Configuration options for Kerberos integration for secured Hadoop clusters
+  # ------------------------------------------------------------------------
+  [[kerberos]]
+
+    # Path to Hue's Kerberos keytab file
+    ## hue_keytab=
+    # Kerberos principal name for Hue
+    ## hue_principal=hue/hostname.foo.com
+    # Path to kinit
+    ## kinit_path=/path/to/kinit
+
+
+###########################################################################
+# Settings to configure your Hadoop cluster.
+###########################################################################
+
+[hadoop]
+
+  # Configuration for HDFS NameNode
+  # ------------------------------------------------------------------------
+  [[hdfs_clusters]]
+
+    [[[default]]]
+      # Enter the filesystem uri
+      fs_defaultfs=hdfs://<%= @namenode_hostname %>/
+
+      # Change this if your HDFS cluster is Kerberos-secured
+      ## security_enabled=false
+
+      # Use WebHdfs/HttpFs as the communication mechanism.
+      # This should be the web service root URL, such as
+      # http://namenode:50070/webhdfs/v1
+      webhdfs_url=http://<%= @namenode_hostname %>:<%= @httpfs_enabled ? '14000' : '50070' %>/webhdfs/v1/
+
+      # Settings about this HDFS cluster. If you install HDFS in a
+      # different location, you need to set the following.
+
+      # Defaults to $HADOOP_HDFS_HOME or /usr/lib/hadoop-hdfs
+      ## hadoop_hdfs_home=/usr/lib/hadoop-hdfs
+
+      # Defaults to $HADOOP_BIN or /usr/bin/hadoop
+      ## hadoop_bin=/usr/bin/hadoop
+
+      # Defaults to $HADOOP_CONF_DIR or /etc/hadoop/conf
+      ## hadoop_conf_dir=/etc/hadoop/conf
+<% 
+# This hue puppetization does not support MRv1.
+if false
+%>
+  # Configuration for MapReduce 0.20 JobTracker (MR1)
+  # ------------------------------------------------------------------------
+  [[mapred_clusters]]
+
+    [[[default]]]
+      # Enter the host on which you are running the Hadoop JobTracker
+      jobtracker_host=localhost
+      # The port where the JobTracker IPC listens on
+      jobtracker_port=8021
+      # Thrift plug-in port for the JobTracker
+      ## thrift_port=9290
+      # Whether to submit jobs to this cluster
+      ## submit_to=True
+
+      # Change this if your MapReduce cluster is Kerberos-secured
+      ## security_enabled=false
+
+      # Settings about this MR1 cluster. If you install MR1 in a
+      # different location, you need to set the following.
+
+      # Defaults to $HADOOP_MR1_HOME or /usr/lib/hadoop-0.20-mapreduce
+      ## hadoop_mapred_home=/usr/lib/hadoop-0.20-mapreduce
+
+      # Defaults to $HADOOP_BIN or /usr/bin/hadoop
+      ## hadoop_bin=/usr/bin/hadoop
+
+      # Defaults to $HADOOP_CONF_DIR or /etc/hadoop/conf
+      ## hadoop_conf_dir=/etc/hadoop/conf
+<% end -%>
+
+  # Configuration for YARN (MR2)
+  # ------------------------------------------------------------------------
+  [[yarn_clusters]]
+
+    [[[default]]]
+      # Enter the host on which you are running the ResourceManager
+      resourcemanager_host=<%= @namenode_hostname %>
+      # The port where the ResourceManager IPC listens on
+      resourcemanager_port=8032
+      # Whether to submit jobs to this cluster
+      submit_to=True
+
+      # Change this if your YARN cluster is Kerberos-secured
+      ## security_enabled=false
+
+      # Settings about this MR2 cluster. If you install MR2 in a
+      # different location, you need to set the following.
+
+      # Defaults to $HADOOP_MR2_HOME or /usr/lib/hadoop-mapreduce
+      ## hadoop_mapred_home=/usr/lib/hadoop-mapreduce
+
+      # Defaults to $HADOOP_BIN or /usr/bin/hadoop
+      ## hadoop_bin=/usr/bin/hadoop
+
+      # Defaults to $HADOOP_CONF_DIR or /etc/hadoop/conf
+      ## hadoop_conf_dir=/etc/hadoop/conf
+
+      # URL of the ResourceManager API
+      ## resourcemanager_api_url=http://<%= @namenode_hostname %>:8088
+
+      # URL of the ProxyServer API
+      proxy_api_url=http://<%= @namenode_hostname %>:8088
+
+      # URL of the HistoryServer API
+      history_server_api_url=http://<%= @namenode_hostname %>:19888
+
+
+<%
+# Enable Hue <-> Oozie API interface if @oozie_url is set.
+if @oozie_url
+-%>
+###########################################################################
+# Settings to configure liboozie
+###########################################################################
+
+[liboozie]
+  # The URL where the Oozie service runs on. This is required in order for
+  # users to submit jobs.
+  oozie_url=<%= @oozie_url %>
+
+  <%= @oozie_security_enabled ? "security_enabled=true" : "## security_enabled=false" %>
+
+  # Location on HDFS where the workflows/coordinator are deployed when submitted.
+  ## remote_deployement_dir=/user/hue/oozie/deployments
+
+
+###########################################################################
+# Settings to configure the Oozie app
+###########################################################################
+
+[oozie]
+  # Location on local FS where the examples are stored.
+  ## local_data_dir=..../examples
+
+  # Location on local FS where the data for the examples is stored.
+  ## sample_data_dir=...thirdparty/sample_data
+
+  # Location on HDFS where the oozie examples and workflows are stored.
+  ## remote_data_dir=/user/hue/oozie/workspaces
+
+  # Share workflows and coordinators information with all users. If set to false,
+  # they will be visible only to the owner and administrators.
+  ## share_jobs=True
+
+  # Maximum of Oozie workflows or coodinators to retrieve in one API call.
+  ## oozie_jobs_count=100
+<% end # if @oozie_url -%>
+
+###########################################################################
+# Settings to configure Beeswax
+###########################################################################
+
+[beeswax]
+
+  # Host where Beeswax server Thrift daemon is running.
+  # If Kerberos security is enabled, the fully-qualified domain name (FQDN) is
+  # required, even if the Thrift daemon is running on the same host as Hue.
+  ## beeswax_server_host=
+
+  # Port where Beeswax Thrift server runs on.
+  ## beeswax_server_port=8002
+
+  # Host where internal metastore Thrift daemon is running.
+  ## beeswax_meta_server_host=localhost
+
+  # Configure the port the internal metastore daemon runs on.
+  # Used only if hive.metastore.local is true.
+  ## beeswax_meta_server_port=8003
+
+  # Hive home directory
+  ## hive_home_dir=/usr/lib/hive
+
+  # Hive configuration directory, where hive-site.xml is located
+  ## hive_conf_dir=/etc/hive/conf
+
+  # Timeout in seconds for thrift calls to beeswax service
+  ## beeswax_server_conn_timeout=120
+
+  # Timeout in seconds for thrift calls to the hive metastore
+  ## metastore_conn_timeout=10
+
+  # Maximum Java heapsize (in megabytes) used by Beeswax Server.
+  # Note that the setting of HADOOP_HEAPSIZE in $HADOOP_CONF_DIR/hadoop-env.sh
+  # may override this setting.
+  ## beeswax_server_heapsize=1000
+
+  # Share saved queries with all users. If set to false, saved queries are
+  # visible only to the owner and administrators.
+  ## share_saved_queries=true
+
+  # The backend to contact for queries/metadata requests.
+  # Choices are 'beeswax' (default), 'hiveserver2'.
+  ## server_interface=beeswax
+
+<%
+# This puppet module does not yet support Impala.
+if false
+-%>
+###########################################################################
+# Settings to configure Impala
+###########################################################################
+
+[impala]
+
+   # Host of the Impala Server
+   ## server_host=localhost
+
+   # Port of the Impala Server
+   ## server_port=21000
+
+<% end -%>
+
+###########################################################################
+# Settings to configure Job Designer
+###########################################################################
+
+[jobsub]
+  # Location on HDFS where the jobsub examples and templates are stored.
+  ## remote_data_dir=/user/hue/jobsub
+
+  # Location on local FS where examples and template are stored.
+  ## local_data_dir=..../data
+
+  # Location on local FS where sample data is stored
+  ## sample_data_dir=...thirdparty/sample_data
+
+
+###########################################################################
+# Settings to configure Job Browser.
+###########################################################################
+
+[jobbrowser]
+  # Share submitted jobs information with all users. If set to false,
+  # submitted jobs are visible only to the owner and administrators.
+  ## share_jobs=true
+
+
+###########################################################################
+# Settings to configure the Shell application
+###########################################################################
+
+[shell]
+  # The shell_buffer_amount specifies the number of bytes of output per shell
+  # that the Shell app will keep in memory. If not specified, it defaults to
+  # 524288 (512 MiB).
+  ## shell_buffer_amount=100
+
+  # If you run Hue against a Hadoop cluster with Kerberos security enabled, the
+  # Shell app needs to acquire delegation tokens for the subprocesses to work
+  # correctly. These delegation tokens are stored as temporary files in some
+  # directory. You can configure this directory here. If not specified, it
+  # defaults to /tmp/hue_delegation_tokens.
+  ## shell_delegation_token_dir=/tmp/hue_delegation_tokens
+
+  [[ shelltypes ]]
+
+    # Define and configure a new shell type "flume"
+    # ------------------------------------------------------------------------
+    # [[[ flume ]]]
+    #   nice_name = "Flume Shell"
+    #   command = "/usr/bin/flume shell"
+    #   help = "The command-line Flume client interface."
+    # 
+    #   [[[[ environment ]]]]
+    #     # You can specify environment variables for the Flume shell
+    #     # in this section.
+
+    # Define and configure a new shell type "pig"
+    # ------------------------------------------------------------------------
+    [[[ pig ]]]
+      nice_name = "Pig Shell (Grunt)"
+      command = "/usr/bin/pig -l /dev/null"
+      help = "The command-line interpreter for Pig"
+
+      [[[[ environment ]]]]
+        # You can specify environment variables for the Pig shell
+        # in this section. Note that JAVA_HOME must be configured
+        # for the Pig shell to run.
+
+        [[[[[ JAVA_HOME ]]]]]
+          value = "/usr/lib/jvm/java-6-sun"
+
+    # Define and configure a new shell type "sqoop2"
+    # ------------------------------------------------------------------------
+    [[[ sqoop2 ]]]
+      nice_name = "Sqoop2 Shell"
+      command = "/usr/bin/sqoop2"
+      help = "The command-line Sqoop2 client."
+
+      [[[[ environment ]]]]
+        # You can configure environment variables for the Sqoop2 shell
+        # in this section.
+
+    # Define and configure a new shell type "hbase"
+    # ------------------------------------------------------------------------
+    [[[ hbase ]]]
+      nice_name = "HBase Shell"
+      command = "/usr/bin/hbase shell"
+      help = "The command-line HBase client interface."
+
+      [[[[ environment ]]]]
+        # You can configure environment variables for the HBase shell
+        # in this section.
+
+    # Define and configure a new shell type "hive"
+    # ------------------------------------------------------------------------
+    [[[ hive ]]]
+      nice_name = "Hive Shell"
+      command = "/usr/bin/hive"
+      help = "The command-line Hive client interface."
+
+      [[[[ environment ]]]]
+      # You can configure environment variables for the Hive shell
+      # in this section.
+
+###########################################################################
+# Settings for the User Admin application
+###########################################################################
+
+[useradmin]
+  # The name of the default user group that users will be a member of
+  ## default_user_group=default

--- a/templates/hue/hue.ini.erb
+++ b/templates/hue/hue.ini.erb
@@ -486,16 +486,18 @@ if false
         [[[[[ JAVA_HOME ]]]]]
           value = "/usr/lib/jvm/java-6-sun"
 
-    # Define and configure a new shell type "sqoop2"
+<% if @sqoop -%>
+    # Define and configure a new shell type "<%= @sqoop %>"
     # ------------------------------------------------------------------------
-    [[[ sqoop2 ]]]
-      nice_name = "Sqoop2 Shell"
-      command = "/usr/bin/sqoop2"
-      help = "The command-line Sqoop2 client."
+    [[[ <%= @sqoop %> ]]]
+      nice_name = "<%= @sqoop %> Shell"
+      command = "/usr/bin/<%= @sqoop %>"
+      help = "The command-line <%= @sqoop %> client."
 
       [[[[ environment ]]]]
-        # You can configure environment variables for the Sqoop2 shell
+        # You can configure environment variables for the <%= @sqoop %> shell
         # in this section.
+<% end # if @sqoop -%>
 
     # Define and configure a new shell type "hbase"
     # ------------------------------------------------------------------------

--- a/templates/hue/hue.ini.erb
+++ b/templates/hue/hue.ini.erb
@@ -57,13 +57,11 @@
   # Number of threads used by the CherryPy web server
   ## cherrypy_server_threads=10
 
-  # Filename of SSL Certificate
-  <%= @ssl_certificate   ? "ssl_certificate=\"#{@ssl_certificate}\"" : "## base_dn=" %>
-
   # Filename of SSL RSA Private Key
-  ## ssl_private_key=
-  <%= @ssl_private_key   ? "ssl_private_key=\"#{@ssl_private_key}\"" : "## base_dn=" %>
+  <%= @ssl_private_key   ? "ssl_private_key=#{@ssl_private_key}" : "## ssl_private_key=" %>
 
+  # Filename of SSL Certificate
+  <%= @ssl_certificate   ? "ssl_certificate=#{@ssl_certificate}" : "## ssl_certificate=" %>
 
   # Default encoding for site data
   ## default_site_encoding=utf-8

--- a/templates/hue/hue.ini.erb
+++ b/templates/hue/hue.ini.erb
@@ -217,7 +217,7 @@
 
     [[[default]]]
       # Enter the filesystem uri
-      fs_defaultfs=hdfs://<%= @namenode_hostname %>/
+      fs_defaultfs=hdfs://<%= @namenode_host %>/
 
       # Change this if your HDFS cluster is Kerberos-secured
       ## security_enabled=false
@@ -225,7 +225,7 @@
       # Use WebHdfs/HttpFs as the communication mechanism.
       # This should be the web service root URL, such as
       # http://namenode:50070/webhdfs/v1
-      webhdfs_url=http://<%= @namenode_hostname %>:<%= @httpfs_enabled ? '14000' : '50070' %>/webhdfs/v1/
+      webhdfs_url=http://<%= @namenode_host %>:<%= @httpfs_enabled ? '14000' : '50070' %>/webhdfs/v1/
 
       # Settings about this HDFS cluster. If you install HDFS in a
       # different location, you need to set the following.
@@ -278,7 +278,7 @@ if false
 
     [[[default]]]
       # Enter the host on which you are running the ResourceManager
-      resourcemanager_host=<%= @namenode_hostname %>
+      resourcemanager_host=<%= @namenode_host %>
       # The port where the ResourceManager IPC listens on
       resourcemanager_port=8032
       # Whether to submit jobs to this cluster
@@ -300,13 +300,13 @@ if false
       ## hadoop_conf_dir=/etc/hadoop/conf
 
       # URL of the ResourceManager API
-      ## resourcemanager_api_url=http://<%= @namenode_hostname %>:8088
+      ## resourcemanager_api_url=http://<%= @namenode_host %>:8088
 
       # URL of the ProxyServer API
-      proxy_api_url=http://<%= @namenode_hostname %>:8088
+      proxy_api_url=http://<%= @namenode_host %>:8088
 
       # URL of the HistoryServer API
-      history_server_api_url=http://<%= @namenode_hostname %>:19888
+      history_server_api_url=http://<%= @namenode_host %>:19888
 
 
 <%

--- a/templates/oozie/oozie-env.sh.erb
+++ b/templates/oozie/oozie-env.sh.erb
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+#  Note: This file is managed by Puppet.
+
+export OOZIE_CONFIG=/etc/oozie/conf
+export OOZIE_DATA=/var/lib/oozie
+export OOZIE_LOG=/var/log/oozie
+export OOZIE_CATALINA_HOME=/usr/lib/bigtop-tomcat
+export CATALINA_TMPDIR=/var/lib/oozie
+export CATALINA_PID=/var/run/oozie/oozie.pid
+export CATALINA_BASE=<%= @catalina_base %>
+export CATALINA_OPTS=-Xmx1024m
+<%
+# This puppet module doesn't (yet) support HTTPS configuration.
+# These are the defaults that ship with CDH4.
+-%>
+export OOZIE_HTTPS_PORT=11443
+export OOZIE_HTTPS_KEYSTORE_PASS=password
+export CATALINA_OPTS="$CATALINA_OPTS -Doozie.https.port=${OOZIE_HTTPS_PORT}"
+export CATALINA_OPTS="$CATALINA_OPTS -Doozie.https.keystore.pass=${OOZIE_HTTPS_KEYSTORE_PASS}"

--- a/templates/oozie/oozie-site.xml.erb
+++ b/templates/oozie/oozie-site.xml.erb
@@ -331,7 +331,7 @@
             The '#USER#' must be replaced with the username o the user who is
             allowed to perform 'doAs' operations.
 
-            The value can be the '*' wildcard or a list of hostnames.
+            The value can be the '*' wildcard or a list of hosts.
 
             For multiple users copy this property and replace the user name
             in the property name.

--- a/templates/oozie/oozie-site.xml.erb
+++ b/templates/oozie/oozie-site.xml.erb
@@ -1,0 +1,413 @@
+<?xml version="1.0"?>
+<!-- NOTE:  This file is managed by Puppet. -->
+
+<configuration>
+
+    <!--
+        Refer to the oozie-default.xml file for the complete list of
+        Oozie configuration properties and their default values.
+    -->
+
+    <property>
+        <name>oozie.service.ActionService.executor.ext.classes</name>
+        <value>
+            org.apache.oozie.action.email.EmailActionExecutor,
+            org.apache.oozie.action.hadoop.HiveActionExecutor,
+            org.apache.oozie.action.hadoop.ShellActionExecutor,
+            org.apache.oozie.action.hadoop.SqoopActionExecutor,
+            org.apache.oozie.action.hadoop.DistcpActionExecutor
+        </value>
+    </property>
+
+    <property>
+        <name>oozie.service.SchemaService.wf.ext.schemas</name>
+        <value>shell-action-0.1.xsd,shell-action-0.2.xsd,email-action-0.1.xsd,hive-action-0.2.xsd,hive-action-0.3.xsd,sqoop-action-0.2.xsd,sqoop-action-0.3.xsd,ssh-action-0.1.xsd,distcp-action-0.1.xsd</value>
+    </property>
+
+    <property>
+        <name>oozie.system.id</name>
+        <value>oozie-${user.name}</value>
+        <description>
+            The Oozie system ID.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.systemmode</name>
+        <value>NORMAL</value>
+        <description>
+            System mode for Oozie at startup.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.AuthorizationService.security.enabled</name>
+        <value><%= @authorization_service_security_enabled %></value>
+        <description>
+            Specifies whether security (user name/admin role) is enabled or not.
+            If disabled any user can manage Oozie system and manage any job.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.PurgeService.older.than</name>
+        <value>30</value>
+        <description>
+            Jobs older than this value, in days, will be purged by the PurgeService.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.PurgeService.purge.interval</name>
+        <value>3600</value>
+        <description>
+            Interval at which the purge service will run, in seconds.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.CallableQueueService.queue.size</name>
+        <value>10000</value>
+        <description>Max callable queue size</description>
+    </property>
+
+    <property>
+        <name>oozie.service.CallableQueueService.threads</name>
+        <value>10</value>
+        <description>Number of threads used for executing callables</description>
+    </property>
+
+    <property>
+        <name>oozie.service.CallableQueueService.callable.concurrency</name>
+        <value>3</value>
+        <description>
+            Maximum concurrency for a given callable type.
+            Each command is a callable type (submit, start, run, signal, job, jobs, suspend,resume, etc).
+            Each action type is a callable type (Map-Reduce, Pig, SSH, FS, sub-workflow, etc).
+            All commands that use action executors (action-start, action-end, action-kill and action-check) use
+            the action type as the callable type.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.coord.normal.default.timeout</name>
+        <value>120</value>
+        <description>
+            Default timeout for a coordinator action input check (in minutes) for normal job.
+            -1 means infinite timeout
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.db.schema.name</name>
+        <value><%= @jdbc_database %></value>
+        <description>
+            Oozie DataBase Name
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.JPAService.create.db.schema</name>
+        <value>true</value>
+        <description>
+            Creates Oozie DB.
+
+            If set to true, it creates the DB schema if it does not exist. If the DB schema exists is a NOP.
+            If set to false, it does not create the DB schema. If the DB schema does not exist it fails start up.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.JPAService.jdbc.driver</name>
+        <value><%= @jdbc_driver %></value>
+        <description>
+            JDBC driver class.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.JPAService.jdbc.url</name>
+        <value><%= "jdbc:#{@jdbc_protocol}://#{@jdbc_host}:#{@jdbc_port}/#{@jdbc_database}" %></value>
+        <description>
+            JDBC URL.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.JPAService.jdbc.username</name>
+        <value><%= @jdbc_username %></value>
+        <description>
+            DB user name.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.JPAService.jdbc.password</name>
+        <value><%= @jdbc_password %></value>
+        <description>
+            DB user password.
+
+            IMPORTANT: if password is empty leave a 1 space string, the service trims the value,
+                       if empty Configuration assumes it is NULL.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.JPAService.pool.max.active.conn</name>
+        <value>10</value>
+        <description>
+             Max number of connections.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.kerberos.enabled</name>
+        <value>false</value>
+        <description>
+            Indicates if Oozie is configured to use Kerberos.
+        </description>
+    </property>
+
+    <property>
+        <name>local.realm</name>
+        <value>LOCALHOST</value>
+        <description>
+            Kerberos Realm used by Oozie and Hadoop. Using 'local.realm' to be aligned with Hadoop configuration
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.keytab.file</name>
+        <value>${user.home}/oozie.keytab</value>
+        <description>
+            Location of the Oozie user keytab file.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.kerberos.principal</name>
+        <value>${user.name}/localhost@${local.realm}</value>
+        <description>
+            Kerberos principal for Oozie service.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.jobTracker.whitelist</name>
+        <value> </value>
+        <description>
+            Whitelisted job tracker for Oozie service.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.nameNode.whitelist</name>
+        <value> </value>
+        <description>
+            Whitelisted job tracker for Oozie service.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.hadoop.configurations</name>
+        <value>*=/etc/hadoop/conf</value>
+        <description>
+            Comma separated AUTHORITY=HADOOP_CONF_DIR, where AUTHORITY is the HOST:PORT of
+            the Hadoop service (JobTracker, HDFS). The wildcard '*' configuration is
+            used when there is no exact match for an authority. The HADOOP_CONF_DIR contains
+            the relevant Hadoop *-site.xml files. If the path is relative is looked within
+            the Oozie configuration directory; though the path can be absolute (i.e. to point
+            to Hadoop client conf/ directories in the local filesystem.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.WorkflowAppService.system.libpath</name>
+        <value>/user/${user.name}/share/lib</value>
+        <description>
+            System library path to use for workflow applications.
+            This path is added to workflow application if their job properties sets
+            the property 'oozie.use.system.libpath' to true.
+        </description>
+    </property>
+
+    <property>
+        <name>use.system.libpath.for.mapreduce.and.pig.jobs</name>
+        <value>false</value>
+        <description>
+            If set to true, submissions of MapReduce and Pig jobs will include
+            automatically the system library path, thus not requiring users to
+            specify where the Pig JAR files are. Instead, the ones from the system
+            library path are used.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.type</name>
+        <value>simple</value>
+        <description>
+            Defines authentication used for Oozie HTTP endpoint.
+            Supported values are: simple | kerberos | #AUTHENTICATION_HANDLER_CLASSNAME#
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.token.validity</name>
+        <value>36000</value>
+        <description>
+            Indicates how long (in seconds) an authentication token is valid before it has
+            to be renewed.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.signature.secret</name>
+        <value>oozie</value>
+        <description>
+            The signature secret for signing the authentication tokens.
+            If not set a random secret is generated at startup time.
+            In order to authentiation to work correctly across multiple hosts
+            the secret must be the same across al the hosts.
+        </description>
+    </property>
+
+    <property>
+      <name>oozie.authentication.cookie.domain</name>
+      <value></value>
+      <description>
+        The domain to use for the HTTP cookie that stores the authentication token.
+        In order to authentiation to work correctly across multiple hosts
+        the domain must be correctly set.
+      </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.simple.anonymous.allowed</name>
+        <value>true</value>
+        <description>
+            Indicates if anonymous requests are allowed.
+            This setting is meaningful only when using 'simple' authentication.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.kerberos.principal</name>
+        <value>HTTP/localhost@${local.realm}</value>
+        <description>
+            Indicates the Kerberos principal to be used for HTTP endpoint.
+            The principal MUST start with 'HTTP/' as per Kerberos HTTP SPNEGO specification.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.kerberos.keytab</name>
+        <value>${oozie.service.HadoopAccessorService.keytab.file}</value>
+        <description>
+            Location of the keytab file with the credentials for the principal.
+            Referring to the same keytab file Oozie uses for its Kerberos credentials for Hadoop.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.kerberos.name.rules</name>
+        <value>DEFAULT</value>
+        <description>
+            The kerberos names rules is to resolve kerberos principal names, refer to Hadoop's
+            KerberosName for more details.
+        </description>
+    </property>
+
+    <!-- Proxyuser Configuration -->
+
+    <!--
+
+    <property>
+        <name>oozie.service.ProxyUserService.proxyuser.#USER#.hosts</name>
+        <value>*</value>
+        <description>
+            List of hosts the '#USER#' user is allowed to perform 'doAs'
+            operations.
+
+            The '#USER#' must be replaced with the username o the user who is
+            allowed to perform 'doAs' operations.
+
+            The value can be the '*' wildcard or a list of hostnames.
+
+            For multiple users copy this property and replace the user name
+            in the property name.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.ProxyUserService.proxyuser.#USER#.groups</name>
+        <value>*</value>
+        <description>
+            List of groups the '#USER#' user is allowed to impersonate users
+            from to perform 'doAs' operations.
+
+            The '#USER#' must be replaced with the username o the user who is
+            allowed to perform 'doAs' operations.
+
+            The value can be the '*' wildcard or a list of groups.
+
+            For multiple users copy this property and replace the user name
+            in the property name.
+        </description>
+    </property>
+
+    -->
+
+    <!-- Default proxyuser configuration for Hue -->
+
+    <property>
+        <name>oozie.service.ProxyUserService.proxyuser.hue.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>oozie.service.ProxyUserService.proxyuser.hue.groups</name>
+        <value>*</value>
+    </property>
+    
+    <!-- enable uber jars -->
+    <property>
+         <name>oozie.action.mapreduce.uber.jar.enable</name>
+         <value>true</value>
+    </property>
+    
+<% if @smtp_host -%>
+    <!-- smtp email configuration -->
+    <property>
+      <name>oozie.email.smtp.host</name>
+      <value><%= @smtp_host %></value>
+    </property>
+    <property>
+      <name>oozie.email.smtp.port</name>
+      <value><%= @smtp_port %></value>
+    </property>
+
+<% if @smtp_from_email -%>
+    <property>
+      <name>oozie.email.from.address</name>
+      <value><%= @smtp_from_email %></value>
+    </property>
+<% end -%>
+
+<% if @smtp_username -%>
+  <property>
+    <name>oozie.email.smtp.auth</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>oozie.email.smtp.username</name>
+    <value><%= @smtp_username %></value>
+  </property>
+  <property>
+    <name>oozie.email.smtp.password</name>
+    <value><%= @smtp_password %></value>
+  </property>
+<% end -%>
+
+<% end # if @smtp_host -%>
+
+</configuration>

--- a/templates/pig/pig.properties.erb
+++ b/templates/pig/pig.properties.erb
@@ -27,7 +27,7 @@ verbose=false
 # hod realted properties
 #ssh.gateway
 #hod.expect.root
-#hod.expect.useensure => installed
+#hod.expect.uselatest
 #hod.command
 #hod.config.dir
 #hod.param

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,12 @@
-MANIFESTS=datanode.po defaults.po hadoop.po historyserver.po  hive.po jobtracker.po Makefile master.po namenode.po nodemanager.po pig.po resourcemanager.po sqoop.po tasktracker.po worker.po
+MANIFESTS=$(wildcard *.pp)
+OBJS=$(MANIFESTS:.pp=.po)
 TESTS_DIR=$(dir $(CURDIR))
 MODULE_DIR=$(TESTS_DIR:/=)
 MODULES_DIR=$(dir $(MODULE_DIR))
 
 all:	test
 
-test: $(MANIFESTS) 
+test:	$(OBJS)
 
 %.po:	%.pp
 	puppet apply --noop --modulepath $(MODULES_DIR) $<

--- a/tests/datanode.pp
+++ b/tests/datanode.pp
@@ -1,8 +1,8 @@
 # 
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+      namenode_hosts => ['localhost'],
+      dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 include cdh4::hadoop::datanode

--- a/tests/hadoop.pp
+++ b/tests/hadoop.pp
@@ -1,7 +1,7 @@
 #
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 

--- a/tests/historyserver.pp
+++ b/tests/historyserver.pp
@@ -1,10 +1,10 @@
 #
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 # historyserver requires namenode
-include cdh4::hadoop::namenode
+include cdh4::hadoop::master
 include cdh4::hadoop::historyserver

--- a/tests/hive.pp
+++ b/tests/hive.pp
@@ -1,6 +1,6 @@
 $fqdn = 'hive1.domain.org'
 class { 'cdh4::hive':
-  metastore_host  => $fqdn,
-  zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
-  jdbc_password   => 'test',
+    metastore_host  => $fqdn,
+    zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
+    jdbc_password   => 'test',
 }

--- a/tests/hive_master.pp
+++ b/tests/hive_master.pp
@@ -1,12 +1,12 @@
 $fqdn = 'hive1.domain.org'
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 class { 'cdh4::hive':
-  metastore_host  => $fqdn,
-  zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
-  jdbc_password   => 'test',
+    metastore_host  => $fqdn,
+    zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
+    jdbc_password   => 'test',
 }
 class { 'cdh4::hive::master': }

--- a/tests/hive_master.pp
+++ b/tests/hive_master.pp
@@ -1,6 +1,12 @@
 $fqdn = 'hive1.domain.org'
+class { '::cdh4::hadoop':
+  namenode_hostname    => 'localhost',
+  dfs_name_dir         => '/var/lib/hadoop/name',
+}
+
 class { 'cdh4::hive':
   metastore_host  => $fqdn,
   zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
   jdbc_password   => 'test',
 }
+class { 'cdh4::hive::master': }

--- a/tests/hive_metastore.pp
+++ b/tests/hive_metastore.pp
@@ -4,3 +4,5 @@ class { 'cdh4::hive':
   zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
   jdbc_password   => 'test',
 }
+class { 'cdh4::hive::metastore': }
+

--- a/tests/hive_metastore.pp
+++ b/tests/hive_metastore.pp
@@ -1,8 +1,8 @@
 $fqdn = 'hive1.domain.org'
 class { 'cdh4::hive':
-  metastore_host  => $fqdn,
-  zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
-  jdbc_password   => 'test',
+    metastore_host  => $fqdn,
+    zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
+    jdbc_password   => 'test',
 }
 class { 'cdh4::hive::metastore': }
 

--- a/tests/hive_metastore_mysql.pp
+++ b/tests/hive_metastore_mysql.pp
@@ -1,8 +1,8 @@
 $fqdn = 'hive1.domain.org'
 class { 'cdh4::hive':
-  metastore_host  => $fqdn,
-  zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
-  jdbc_password   => 'test',
+    metastore_host  => $fqdn,
+    zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
+    jdbc_password   => 'test',
 }
 class { 'cdh4::hive::metastore::mysql': }
 

--- a/tests/hive_metastore_mysql.pp
+++ b/tests/hive_metastore_mysql.pp
@@ -4,3 +4,5 @@ class { 'cdh4::hive':
   zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
   jdbc_password   => 'test',
 }
+class { 'cdh4::hive::metastore::mysql': }
+

--- a/tests/hive_server.pp
+++ b/tests/hive_server.pp
@@ -1,6 +1,13 @@
 $fqdn = 'hive1.domain.org'
+class { '::cdh4::hadoop':
+  namenode_hostname    => 'localhost',
+  dfs_name_dir         => '/var/lib/hadoop/name',
+}
+
 class { 'cdh4::hive':
   metastore_host  => $fqdn,
   zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
   jdbc_password   => 'test',
 }
+class { 'cdh4::hive::server': }
+

--- a/tests/hive_server.pp
+++ b/tests/hive_server.pp
@@ -1,13 +1,13 @@
 $fqdn = 'hive1.domain.org'
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 class { 'cdh4::hive':
-  metastore_host  => $fqdn,
-  zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
-  jdbc_password   => 'test',
+    metastore_host  => $fqdn,
+    zookeeper_hosts => ['zk1.domain.org', 'zk2.domain.org'],
+    jdbc_password   => 'test',
 }
 class { 'cdh4::hive::server': }
 

--- a/tests/jobtracker.pp
+++ b/tests/jobtracker.pp
@@ -1,11 +1,10 @@
-# 
 
 class { '::cdh4::hadoop':
-  use_yarn             => false,
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    use_yarn       => false,
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 # jobtracker requires namenode
-include cdh4::hadoop::namenode
+include cdh4::hadoop::master
 include cdh4::hadoop::jobtracker

--- a/tests/master.pp
+++ b/tests/master.pp
@@ -1,8 +1,8 @@
-# 
+#
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 include cdh4::hadoop::master

--- a/tests/namenode.pp
+++ b/tests/namenode.pp
@@ -1,8 +1,8 @@
-# 
+#
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 include cdh4::hadoop::namenode

--- a/tests/namenode_primary.pp
+++ b/tests/namenode_primary.pp
@@ -1,0 +1,10 @@
+#
+
+class { '::cdh4::hadoop':
+    namenode_hosts    => ['localhost', 'nonya'],
+    dfs_name_dir      => '/var/lib/hadoop/name',
+    nameservice_id    => 'test-cdh4',
+    journalnode_hosts => ['localhost', 'nonya'],
+}
+
+include cdh4::hadoop::namenode::primary

--- a/tests/namenode_standby.pp
+++ b/tests/namenode_standby.pp
@@ -1,0 +1,10 @@
+#
+
+class { '::cdh4::hadoop':
+    namenode_hosts    => ['localhost', 'nonya'],
+    dfs_name_dir      => '/var/lib/hadoop/name',
+    nameservice_id    => 'test-cdh4',
+    journalnode_hosts => ['localhost', 'nonya'],
+}
+
+include cdh4::hadoop::namenode::standby

--- a/tests/nodemanager.pp
+++ b/tests/nodemanager.pp
@@ -1,8 +1,8 @@
-# 
+#
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 include cdh4::hadoop::nodemanager

--- a/tests/resourcemanager.pp
+++ b/tests/resourcemanager.pp
@@ -1,10 +1,10 @@
-# 
+#
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 # resourcemanager requires namenode
-include cdh4::hadoop::namenode
+include cdh4::hadoop::master
 include cdh4::hadoop::resourcemanager

--- a/tests/tasktracker.pp
+++ b/tests/tasktracker.pp
@@ -1,9 +1,9 @@
-# 
+#
 
 class { '::cdh4::hadoop':
-  use_yarn             => false,
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
+    use_yarn       => false,
+    namenode_hosts => ['localhost'],
+    dfs_name_dir   => '/var/lib/hadoop/name',
 }
 
 include cdh4::hadoop::tasktracker

--- a/tests/worker.pp
+++ b/tests/worker.pp
@@ -1,9 +1,9 @@
-# 
+#
 
 class { '::cdh4::hadoop':
-  namenode_hostname    => 'localhost',
-  dfs_name_dir         => '/var/lib/hadoop/name',
-  datanode_mounts      => '/tmp',
+    namenode_hosts  => 'localhost',
+    dfs_name_dir    => '/var/lib/hadoop/name',
+    datanode_mounts => '/tmp',
 }
 
 include cdh4::hadoop::worker


### PR DESCRIPTION
Copy of https://github.com/wikimedia/operations-puppet-cdh4/pull/2

Added HBase support. Configuration is very basic so far.

Prereq:
Have Zookeeper server up and running manually or by puppet.

Usage:
On HBase-Master:

```
class {'cdh4::hbase':
    zookeeper_hosts => ['hbase-master.domain.com'],
}
include cdh4::hbase::master
```

On HBase-Regionservers:

```
class {'cdh4::hbase':
    zookeeper_hosts => ['hbase-master.domain.com'],
}
include cdh4::hbase::regionserver
```

You can also install/include both master and regionserver on the same host. HBase will then run in pseudo-distributed mode.
