### PR TITLE
Export the hadoop heapsize, 

### DIFF
--- a/templates/hive/hive-metastore.default.erb
+++ b/templates/hive/hive-metastore.default.erb
@@ -22,5 +22,5 @@
 <%= @port ? "PORT=#{@port}" : '#PORT=' %>
 
 <% if @heapsize -%>
-HADOOP_HEAPSIZE=<%= @heapsize %>
+export HADOOP_HEAPSIZE=<%= @heapsize %>
 <% end -%>

--- a/templates/hive/hive-server2.default.erb
+++ b/templates/hive/hive-server2.default.erb
@@ -22,5 +22,5 @@
 <%= @port ? "PORT=#{@port}" : '#PORT=' %>
 
 <% if @heapsize -%>
-HADOOP_HEAPSIZE=<%= @heapsize %>
+export HADOOP_HEAPSIZE=<%= @heapsize %>
 <% end -%>


### PR DESCRIPTION
…otherwise it will use the default 256mb which is not enough for production workloads

Signed-off-by: Patrick Van Brussel patrick@inuits.eu
