### PR TITLE
Added some important parameters to hdfs-site.xml

### DIFF
--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -12,25 +12,27 @@
 # yarn.nodemanager.log-dirs will be set to each of ${dfs_data_dir_mounts}/$yarn_logs_path
 #
 # == Parameters
-#   $namenode_hosts             - Array of NameNode host(s).  The first entry in this
-#                                 array will be the primary NameNode.  The primary NameNode
-#                                 will also be used as the host for the historyserver, proxyserver,
-#                                 and resourcemanager.   Use multiple hosts hosts if you
-#                                 configuring Hadoop with HA NameNodes.
-#   $dfs_name_dir               - Path to hadoop NameNode name directory.  This
-#                                 can be an array of paths or a single string path.
-#   $cluster_name               - Arbitrary logical HDFS cluster name.  This will be used
-#                                 as the nameserivce id if you set $ha_enabled to true.
-#                                 Default: 'cdh'.
-#   $journalnode_hosts          - Array of JournalNode hosts.  If this is provided,
-#                                 Hadoop will be configured to expect to have
-#                                 a primary NameNode as well as at least
-#                                 one Standby NameNode for use in high availibility mode.
-#   $dfs_journalnode_edits_dir  - Path to JournalNode edits dir.  This will be
-#                                 ignored if $ha_enabled is false.
-#   $datanode_mounts            - Array of JBOD mount points.  Hadoop datanode and
-#                                 mapreduce/yarn directories will be here.
-#   $dfs_data_path              - Path relative to JBOD mount point for HDFS data directories.
+#   $namenode_hosts                     - Array of NameNode host(s).  The first entry in this
+#                                         array will be the primary NameNode.  The primary NameNode
+#                                         will also be used as the host for the historyserver, proxyserver,
+#                                         and resourcemanager.   Use multiple hosts hosts if you
+#                                         configuring Hadoop with HA NameNodes.
+#   $dfs_name_dir                       - Path to hadoop NameNode name directory.  This
+#                                         can be an array of paths or a single string path.
+#   $cluster_name                       - Arbitrary logical HDFS cluster name.  This will be used
+#                                         as the nameserivce id if you set $ha_enabled to true.
+#                                         Default: 'cdh'.
+#   $journalnode_hosts                  - Array of JournalNode hosts.  If this is provided,
+#                                         Hadoop will be configured to expect to have
+#                                         a primary NameNode as well as at least
+#                                         one Standby NameNode for use in high availibility mode.
+#   $dfs_journalnode_edits_dir          - Path to JournalNode edits dir.  This will be
+#                                         ignored if $ha_enabled is false.
+#   $datanode_mounts                    - Array of JBOD mount points.  Hadoop datanode and
+#                                         mapreduce/yarn directories will be here.
+#   $dfs_data_path                      - Path relative to JBOD mount point for HDFS data directories.
+#   $datanode_failed_volumes_tolerated  - The number of volumes that are allowed to fail before a datanode stops offering service.
+#                                         Default: 0 
 #
 #   $resourcemanager_hosts      - Array of hosts on which ResourceManager is running.  If this has
 #                                 more than one host in it AND $zookeeper_hosts is set, HA YARN ResourceManager
@@ -122,6 +124,7 @@ class cdh::hadoop(
 
     $datanode_mounts                             = $::cdh::hadoop::defaults::datanode_mounts,
     $dfs_data_path                               = $::cdh::hadoop::defaults::dfs_data_path,
+    $datanode_failed_volumes_tolerated           = $::cdh::hadoop::defaults::datanode_failed_volumes_tolerated,
 
     $resourcemanager_hosts                       = $namenode_hosts,
     $zookeeper_hosts                             = $::cdh::hadoop::defaults::zookeeper_hosts,

--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -47,6 +47,7 @@
 #   $yarn_local_path            - Path relative to JBOD mount point for yarn local directories.
 #   $yarn_logs_path             - Path relative to JBOD mount point for yarn log directories.
 #   $dfs_block_size             - HDFS block size in bytes.  Default 64MB.
+#   $dfs_replication            - Default block replication. Default: 3
 #   $io_file_buffer_size
 #   $map_tasks_maximum
 #   $reduce_tasks_maximum
@@ -132,6 +133,7 @@ class cdh::hadoop(
     $yarn_local_path                             = $::cdh::hadoop::defaults::yarn_local_path,
     $yarn_logs_path                              = $::cdh::hadoop::defaults::yarn_logs_path,
     $dfs_block_size                              = $::cdh::hadoop::defaults::dfs_block_size,
+    $dfs_replication                             = $::cdh::hadoop::defaults::dfs_replication,
     $enable_jmxremote                            = $::cdh::hadoop::defaults::enable_jmxremote,
     $webhdfs_enabled                             = $::cdh::hadoop::defaults::webhdfs_enabled,
     $httpfs_enabled                              = $::cdh::hadoop::defaults::httpfs_enabled,

--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -115,6 +115,8 @@
 #                                               be disabled.  Default: cdh/hadoop/fair-scheduler.xml.erb
 #   $yarn_site_extra_properties               - Hash of extra property names to values that will be
 #                                               be rendered in yarn-site.xml.erb.  Default: undef
+#   $hdfs_site_extra_properties               - Hash of extra property names to values that will be
+#                                               rendered in hdfs-site.xml.erb. Default: undef
 #
 class cdh::hadoop(
     $namenode_hosts,
@@ -174,6 +176,7 @@ class cdh::hadoop(
     $gelf_logging_port                           = $::cdh::hadoop::defaults::gelf_logging_port,
     $fair_scheduler_template                     = $::cdh::hadoop::defaults::fair_scheduler_template,
     $yarn_site_extra_properties                  = $::cdh::hadoop::defaults::yarn_site_extra_properties,
+    $hdfs_site_extra_properties                  = $::cdh::hadoop::defaults::hdfs_site_extra_properties,
 ) inherits cdh::hadoop::defaults
 {
     # If $dfs_name_dir is a list, this will be the

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -57,6 +57,7 @@ class cdh::hadoop::defaults {
 
     $fair_scheduler_template                  = 'cdh/hadoop/fair-scheduler.xml.erb'
     $yarn_site_extra_properties               = undef
+    $hdfs_site_extra_properties               = undef
 
     $hadoop_heapsize                          = undef
     $hadoop_namenode_opts                     = undef

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -17,6 +17,7 @@ class cdh::hadoop::defaults {
     $yarn_local_path                          = 'yarn/local'
     $yarn_logs_path                           = 'yarn/logs'
     $dfs_block_size                           = 67108864 # 64MB default
+    $dfs_replication                          = 3
     $enable_jmxremote                         = true
     $webhdfs_enabled                          = false
     $httpfs_enabled                           = true

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -8,6 +8,7 @@ class cdh::hadoop::defaults {
 
     $datanode_mounts                          = undef
     $dfs_data_path                            = 'hdfs/dn'
+    $datanode_failed_volumes_tolerated        = 0
 
     # $resourcemanager_hosts is not set here, because it defaults to the user
     # provided value of $namenode_hosts in hadoop.pp.

--- a/manifests/oozie/server.pp
+++ b/manifests/oozie/server.pp
@@ -117,7 +117,7 @@ class cdh::oozie::server(
     }
 
     # Put oozie sharelib into HDFS:
-    $oozie_sharelib_archive = '/usr/lib/oozie/oozie-sharelib-yarn.tar.gz'
+    $oozie_sharelib_archive = '/usr/lib/oozie/oozie-sharelib-yarn'
     $hdfs_uri               = "hdfs://${cdh::hadoop::namenode_hosts[0]}"
 
     exec { 'oozie_sharelib_install':

--- a/templates/hadoop/hdfs-site.xml.erb
+++ b/templates/hadoop/hdfs-site.xml.erb
@@ -96,6 +96,11 @@ end
    <value><%= @dfs_block_size %></value>
   </property>
 
+  <property>
+    <name>dfs.replication</name>
+    <value><%= @dfs_replication %></value>
+  </property>  
+
 <% if @dfs_datanode_hdfs_blocks_metadata_enabled -%>
   <property>
     <name>dfs.datanode.hdfs-blocks-metadata.enabled</name>

--- a/templates/hadoop/hdfs-site.xml.erb
+++ b/templates/hadoop/hdfs-site.xml.erb
@@ -136,6 +136,15 @@ end
     <value><%= @datanode_failed_volumes_tolerated %></value>
   </property>
 
+<% if @hdfs_site_extra_properties -%>
+<% @hdfs_site_extra_properties.sort.map do |key, value| -%>
+  <property>
+    <name><%= key %></name>
+    <value><%= value %></value>
+  </property>
+<% end -%>
+<% end -%>
+
 <% if @hdfs_site_impala_extra_properties
 # Impala requires that a special hdfs-site.xml file is rendered at
 # /etc/impala/conf/hdfs-site.xml.  This property allows the

--- a/templates/hadoop/hdfs-site.xml.erb
+++ b/templates/hadoop/hdfs-site.xml.erb
@@ -125,6 +125,11 @@ end
       This is useful for decommissioning nodes.
     </description>
   </property>
+  
+  <property>
+    <name>dfs.datanode.failed.volumes.tolerated</name>
+    <value><%= @datanode_failed_volumes_tolerated %></value>
+  </property>
 
 <% if @hdfs_site_impala_extra_properties
 # Impala requires that a special hdfs-site.xml file is rendered at


### PR DESCRIPTION
Added dfs.datanode.failed.volumes.tolerated as module parameter.
Added dfs.replication as module parameter to set the replication facter of hdfs filesystem.
Opportunity to add additional parameters to hdfs-site.xml as hash.
